### PR TITLE
feat: add OpenAI/Codex provider support (LIM-24)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,15 +5,23 @@
 
 # ── Required ─────────────────────────────────────────────────────────────────
 
-# Anthropic API key for Claude (required)
-ANTHROPIC_API_KEY=sk-ant-...
+# Generic LLM API key — used by whichever provider you select below.
+# For Anthropic: sk-ant-...
+# For OpenAI:    sk-...
+LLM_API_KEY=
+
+# Legacy alias — still accepted for backwards compatibility.
+# If LLM_API_KEY is not set, ANTHROPIC_API_KEY is used as a fallback.
+# ANTHROPIC_API_KEY=sk-ant-...
 
 # ── Model (optional) ─────────────────────────────────────────────────────────
 
-# AI provider: anthropic (default)
+# AI provider: anthropic (default) | openai
 # MODEL_PROVIDER=anthropic
 
-# Model name to use
+# Model name to use.
+# Anthropic default: claude-sonnet-4-6
+# OpenAI / Codex:    codex-mini-latest  (or gpt-4o, o1, etc.)
 # MODEL_NAME=claude-sonnet-4-6
 
 # ── Telegram Integration (optional) ──────────────────────────────────────────

--- a/README.md
+++ b/README.md
@@ -36,11 +36,14 @@ Copy `.env.example` to `.env` and set:
 
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `ANTHROPIC_API_KEY` | **yes** | — | API key for the Claude model |
-| `MODEL_PROVIDER` | no | `anthropic` | Model provider |
-| `MODEL_NAME` | no | `claude-sonnet-4-6` | Model name |
+| `LLM_API_KEY` | **yes*** | — | API key for your chosen model provider (Anthropic or OpenAI) |
+| `ANTHROPIC_API_KEY` | **yes*** | — | Legacy alias for `LLM_API_KEY` — accepted for backwards compatibility |
+| `MODEL_PROVIDER` | no | `anthropic` | Model provider: `anthropic` or `openai` |
+| `MODEL_NAME` | no | `claude-sonnet-4-6` | Model name (e.g. `claude-sonnet-4-6`, `codex-mini-latest`, `gpt-4o`) |
 | `TELEGRAM_ENABLED` | no | `false` | Enable Telegram bot integration |
 | `TELEGRAM_BOT_TOKEN` | no | — | Telegram bot token (required if `TELEGRAM_ENABLED=true`) |
+
+> \* Either `LLM_API_KEY` **or** `ANTHROPIC_API_KEY` is required. `LLM_API_KEY` takes precedence if both are set.
 
 ---
 
@@ -119,7 +122,7 @@ VAULT_PATH=./dev-vault node index.js
 
 ```sh
 docker build -t limbo:dev .
-docker run --rm -e ANTHROPIC_API_KEY=sk-... -p 18789:18789 limbo:dev
+docker run --rm -e LLM_API_KEY=sk-ant-... -p 18789:18789 limbo:dev
 ```
 
 ### Run migrations standalone

--- a/openclaw.json.template
+++ b/openclaw.json.template
@@ -6,7 +6,7 @@
   "model": {
     "provider": "${MODEL_PROVIDER}",
     "name": "${MODEL_NAME}",
-    "apiKey": "${ANTHROPIC_API_KEY}"
+    "apiKey": "${LLM_API_KEY}"
   },
   "integrations": {
     "telegram": {

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -19,10 +19,14 @@ log() {
 log "INFO  Limbo container starting"
 
 # ── Validate required env vars ───────────────────────────────────────────────
-if [ -z "$ANTHROPIC_API_KEY" ]; then
-  log "ERROR ANTHROPIC_API_KEY is required"
+# Accept LLM_API_KEY (generic) or ANTHROPIC_API_KEY (backwards compat)
+if [ -z "${LLM_API_KEY:-}" ] && [ -z "${ANTHROPIC_API_KEY:-}" ]; then
+  log "ERROR LLM_API_KEY (or ANTHROPIC_API_KEY for backwards compat) is required"
   exit 1
 fi
+
+# Resolve to LLM_API_KEY — prefer explicit, fall back to legacy var
+LLM_API_KEY="${LLM_API_KEY:-$ANTHROPIC_API_KEY}"
 
 # ── Defaults ─────────────────────────────────────────────────────────────────
 MODEL_PROVIDER="${MODEL_PROVIDER:-anthropic}"
@@ -36,8 +40,8 @@ mkdir -p /data/db /data/backups /data/logs
 # ── Generate openclaw.json from template ─────────────────────────────────────
 log "INFO  Generating /app/openclaw.json from template"
 
-export MODEL_PROVIDER MODEL_NAME ANTHROPIC_API_KEY TELEGRAM_ENABLED TELEGRAM_BOT_TOKEN
-envsubst '$MODEL_PROVIDER $MODEL_NAME $ANTHROPIC_API_KEY $TELEGRAM_ENABLED $TELEGRAM_BOT_TOKEN' \
+export MODEL_PROVIDER MODEL_NAME LLM_API_KEY TELEGRAM_ENABLED TELEGRAM_BOT_TOKEN
+envsubst '$MODEL_PROVIDER $MODEL_NAME $LLM_API_KEY $TELEGRAM_ENABLED $TELEGRAM_BOT_TOKEN' \
   < /app/openclaw.json.template > /app/openclaw.json
 
 log "INFO  openclaw.json written"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -93,7 +93,7 @@ log "Directory /opt/limbo ready."
 
 # ─── Collect API keys ─────────────────────────────────────────────────────────
 header "Configuration"
-echo "You'll need an Anthropic API key (get one at https://console.anthropic.com)."
+echo "Limbo supports Anthropic (Claude) and OpenAI (Codex/GPT) as model providers."
 echo "Telegram integration is optional — skip by pressing Enter."
 echo ""
 
@@ -118,7 +118,23 @@ prompt_optional() {
   printf -v "$varname" '%s' "${value:-$default}"
 }
 
-prompt_required ANTHROPIC_API_KEY "Anthropic API key (sk-ant-...)"
+# Provider selection
+prompt_optional MODEL_PROVIDER "Model provider (anthropic/openai)" "anthropic"
+
+case "$MODEL_PROVIDER" in
+  openai)
+    DEFAULT_MODEL_NAME="codex-mini-latest"
+    KEY_LABEL="OpenAI API key (sk-...)"
+    ;;
+  *)
+    MODEL_PROVIDER="anthropic"
+    DEFAULT_MODEL_NAME="claude-sonnet-4-6"
+    KEY_LABEL="Anthropic API key (sk-ant-...)"
+    ;;
+esac
+
+prompt_required LLM_API_KEY "$KEY_LABEL"
+prompt_optional MODEL_NAME  "Model name" "$DEFAULT_MODEL_NAME"
 
 prompt_optional TELEGRAM_ENABLED "Enable Telegram bot? (true/false)" "false"
 TELEGRAM_BOT_TOKEN=""
@@ -126,13 +142,10 @@ if [[ "$TELEGRAM_ENABLED" == "true" ]]; then
   prompt_required TELEGRAM_BOT_TOKEN "Telegram bot token"
 fi
 
-prompt_optional MODEL_PROVIDER "Model provider" "anthropic"
-prompt_optional MODEL_NAME     "Model name"     "claude-sonnet-4-6"
-
 # ─── Write .env ───────────────────────────────────────────────────────────────
 header "Writing /opt/limbo/.env..."
 cat > /opt/limbo/.env <<EOF
-ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
+LLM_API_KEY=${LLM_API_KEY}
 MODEL_PROVIDER=${MODEL_PROVIDER}
 MODEL_NAME=${MODEL_NAME}
 TELEGRAM_ENABLED=${TELEGRAM_ENABLED}


### PR DESCRIPTION
## Summary

- Introduces `LLM_API_KEY` as the generic API key variable so either Anthropic or OpenAI keys work without renaming
- `ANTHROPIC_API_KEY` is still accepted as a backwards-compatible fallback
- `install.sh` now asks for provider first and sets the appropriate label/default model
- `openclaw.json.template` uses `${LLM_API_KEY}` (resolved at container start)
- `README.md` and `.env.example` updated to document both variables

## Test plan

- [ ] `docker run -e LLM_API_KEY=sk-ant-... limbo:dev` — Anthropic path still works
- [ ] `docker run -e ANTHROPIC_API_KEY=sk-ant-... limbo:dev` — legacy var still works (fallback)
- [ ] `docker run -e LLM_API_KEY=sk-... -e MODEL_PROVIDER=openai -e MODEL_NAME=codex-mini-latest limbo:dev` — OpenAI path
- [ ] `install.sh`: select `openai` provider, confirm key label and default model name change
- [ ] Missing key → entrypoint exits with clear error message

Closes LIM-24

🤖 Generated with [Claude Code](https://claude.com/claude-code)