### PR TITLE
feat: integrate mcporter for vault MCP tool access

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,8 @@ WORKDIR /build
 RUN apt-get update && apt-get install -y --no-install-recommends git ca-certificates && rm -rf /var/lib/apt/lists/* \
   && git config --global url."https://github.com/".insteadOf "ssh://git@github.com/"
 
-# Install OpenClaw globally
-RUN npm install -g openclaw
+# Install OpenClaw and mcporter globally
+RUN npm install -g openclaw mcporter
 
 # Copy MCP server and install its deps
 COPY mcp-server/package.json mcp-server/package-lock.json* ./mcp-server/
@@ -23,12 +23,15 @@ RUN cd mcp-server && npm ci --omit=dev
 # ──────────────────────────────────────────────
 FROM node:22-slim AS runtime
 
-# Non-root user for security
-RUN groupadd -r limbo && useradd -r -g limbo limbo
+# Non-root user for security + envsubst for template rendering
+RUN apt-get update && apt-get install -y --no-install-recommends gettext-base && rm -rf /var/lib/apt/lists/* \
+  && groupadd -r limbo && useradd --create-home -r -g limbo limbo
 
 # Copy OpenClaw from deps stage (global npm install)
+# Use symlink so that relative imports in openclaw.mjs resolve correctly
 COPY --from=deps /usr/local/lib/node_modules /usr/local/lib/node_modules
-COPY --from=deps /usr/local/bin/openclaw /usr/local/bin/openclaw
+RUN ln -s /usr/local/lib/node_modules/openclaw/openclaw.mjs /usr/local/bin/openclaw \
+  && ln -s /usr/local/lib/node_modules/mcporter/dist/cli.js /usr/local/bin/mcporter
 
 # App directories
 WORKDIR /app
@@ -46,6 +49,9 @@ COPY --chown=limbo:limbo migrations/ ./migrations/
 # openclaw.json template (populated by entrypoint from env vars)
 COPY --chown=limbo:limbo openclaw.json.template ./openclaw.json.template
 
+# mcporter config — registers the limbo-vault MCP stdio server
+COPY --chown=limbo:limbo mcporter.json ./mcporter.json
+
 # Entrypoint script (runs as root so it can set up /data, then drops to limbo)
 COPY scripts/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
@@ -53,6 +59,9 @@ RUN chmod +x /entrypoint.sh
 # Pre-create /data with correct ownership so the non-root user can write to it
 # The actual subdirectories are created by entrypoint.sh on first run
 RUN mkdir -p /data && chown limbo:limbo /data
+
+# Make /app writable by limbo so entrypoint can write openclaw.json
+RUN chown limbo:limbo /app
 
 # Data volume — vault, db, config, memory, backups, logs
 VOLUME ["/data"]

--- a/mcporter.json
+++ b/mcporter.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "limbo-vault": {
+      "command": "node",
+      "args": ["/app/mcp-server/index.js"],
+      "description": "Limbo personal memory vault — search, read, write notes and update maps"
+    }
+  }
+}

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -34,8 +34,14 @@ MODEL_NAME="${MODEL_NAME:-claude-sonnet-4-6}"
 TELEGRAM_ENABLED="${TELEGRAM_ENABLED:-false}"
 TELEGRAM_BOT_TOKEN="${TELEGRAM_BOT_TOKEN:-}"
 
-# ── Bootstrap log dir (migration runner needs /data/logs first) ───────────────
-mkdir -p /data/db /data/backups /data/logs
+# ── Bootstrap data dirs ───────────────────────────────────────────────────────
+mkdir -p /data/db /data/backups /data/logs /data/vault
+
+# ── Bootstrap workspace (first-run: seed from baked-in template) ──────────────
+if [ ! -d /data/workspace ]; then
+  log "INFO  First run — seeding workspace from template"
+  cp -r /app/workspace /data/workspace
+fi
 
 # ── Generate openclaw.json from template ─────────────────────────────────────
 log "INFO  Generating /app/openclaw.json from template"
@@ -50,6 +56,10 @@ log "INFO  openclaw.json written"
 log "INFO  Running migration runner"
 node /app/migrations/index.js
 log "INFO  Migrations OK"
+
+# ── Configure mcporter ────────────────────────────────────────────────────────
+export MCPORTER_CONFIG=/app/mcporter.json
+log "INFO  mcporter configured — MCPORTER_CONFIG=$MCPORTER_CONFIG"
 
 # ── Start OpenClaw gateway ────────────────────────────────────────────────────
 log "INFO  Starting OpenClaw gateway"

--- a/workspace/AGENTS.md
+++ b/workspace/AGENTS.md
@@ -1,6 +1,6 @@
 # How to Use Your Tools
 
-You have 4 vault tools. This document explains when and how to use each one correctly.
+You have 4 vault tools accessible via `mcporter call`. This document explains when and how to use each one correctly.
 
 ## General Rules
 
@@ -15,8 +15,8 @@ You have 4 vault tools. This document explains when and how to use each one corr
 
 Use when: the user asks a question, recalls something, or you need to check if a note already exists.
 
-```
-vault_search(query: string)
+```sh
+mcporter call limbo-vault.vault_search query="your search term"
 ```
 
 - `query` accepts regex or plain keywords
@@ -36,8 +36,8 @@ vault_search(query: string)
 
 Use when: you found a note via search and need its full content.
 
-```
-vault_read(noteId: string)
+```sh
+mcporter call limbo-vault.vault_read noteId="note-id-here"
 ```
 
 - `noteId` is the filename without the `.md` extension
@@ -50,15 +50,14 @@ vault_read(noteId: string)
 
 Use when: the user shares something worth remembering, or asks you to capture/save something.
 
-```
-vault_write_note(
-  id: string,         // unique, alphanumeric + dashes/underscores
-  title: string,      // human-readable, descriptive
-  type: string,       // claim | source | concept | question | person | project | event
-  description: string, // one sentence summarizing the core idea
-  content: string,    // full markdown body
-  map?: string        // MOC this note belongs to (omit if unclear)
-)
+```sh
+mcporter call limbo-vault.vault_write_note \
+  id="note-id" \
+  title="Note Title" \
+  type="claim" \
+  description="One sentence summarizing the core idea." \
+  content="Full markdown body." \
+  map="optional-moc-name"
 ```
 
 **ID conventions:**
@@ -86,12 +85,11 @@ vault_write_note(
 
 Use when: you've written a note that belongs to a Map of Content (MOC), or the user asks to organize notes.
 
-```
-vault_update_map(
-  map: string,       // MOC filename without extension
-  section: string,   // section heading to append under
-  entries: string[]  // markdown link strings, e.g. ["[[note-id|Note Title]]"]
-)
+```sh
+mcporter call limbo-vault.vault_update_map \
+  map="map-name" \
+  section="Section Heading" \
+  entries='["[[note-id|Note Title]]"]'
 ```
 
 - Creates the map file and/or section if they don't exist
@@ -108,16 +106,16 @@ vault_update_map(
 ## Common Patterns
 
 **Capture a new fact:**
-1. `vault_search` to check for duplicates
-2. `vault_write_note` with appropriate type and map
-3. `vault_update_map` if a relevant MOC exists
+1. `mcporter call limbo-vault.vault_search query="..."` to check for duplicates
+2. `mcporter call limbo-vault.vault_write_note ...` with appropriate type and map
+3. `mcporter call limbo-vault.vault_update_map ...` if a relevant MOC exists
 
 **Answer a recall question:**
-1. `vault_search` with relevant keywords
-2. `vault_read` on top results if needed
+1. `mcporter call limbo-vault.vault_search query="..."` with relevant keywords
+2. `mcporter call limbo-vault.vault_read noteId="..."` on top results if needed
 3. Synthesize and respond — cite note IDs when quoting
 
 **Organize a topic:**
-1. `vault_search` to find all related notes
-2. `vault_update_map` to collect them under a coherent section
+1. `mcporter call limbo-vault.vault_search query="..."` to find all related notes
+2. `mcporter call limbo-vault.vault_update_map ...` to collect them under a coherent section
 3. Report what you found and organized

--- a/workspace/TOOLS.md
+++ b/workspace/TOOLS.md
@@ -1,12 +1,23 @@
 # Available Tools
 
-You have access to one MCP server: **limbo-vault**. It provides 4 tools for reading and writing the user's vault.
+You have access to the **limbo-vault** MCP server via **mcporter**. Call tools from the shell using the `mcporter call` command.
+
+```sh
+mcporter call limbo-vault.<tool_name> <key>=<value> ...
+```
+
+The `MCPORTER_CONFIG` environment variable is pre-set to `/app/mcporter.json`, which registers the limbo-vault server.
 
 ---
 
 ## vault_search
 
 Search notes in the vault by regex or keyword query.
+
+**Shell call:**
+```sh
+mcporter call limbo-vault.vault_search query="your search term"
+```
 
 **Input:**
 | Field | Type | Required | Description |
@@ -21,6 +32,11 @@ Search notes in the vault by regex or keyword query.
 
 Read the full content of a vault note by ID.
 
+**Shell call:**
+```sh
+mcporter call limbo-vault.vault_read noteId="note-id-here"
+```
+
 **Input:**
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
@@ -33,6 +49,17 @@ Read the full content of a vault note by ID.
 ## vault_write_note
 
 Create or overwrite a vault note with YAML frontmatter.
+
+**Shell call:**
+```sh
+mcporter call limbo-vault.vault_write_note \
+  id="note-id" \
+  title="Note Title" \
+  type="claim" \
+  description="One-sentence summary of the note's core claim." \
+  content="Full markdown body of the note." \
+  map="optional-moc-name"
+```
 
 **Input:**
 | Field | Type | Required | Description |
@@ -51,6 +78,14 @@ Create or overwrite a vault note with YAML frontmatter.
 ## vault_update_map
 
 Append entries to a section in a Map of Content (MOC). Creates the map file and/or section if they don't exist.
+
+**Shell call:**
+```sh
+mcporter call limbo-vault.vault_update_map \
+  map="map-name" \
+  section="Section Heading" \
+  entries='["[[note-id|Note Title]]"]'
+```
 
 **Input:**
 | Field | Type | Required | Description |


### PR DESCRIPTION
## Summary

- Wires the Limbo vault MCP server into the Docker image via [mcporter](https://github.com/steipete/mcporter) as a CLI bridge (OpenClaw has no native `mcp.servers` support)
- Installs mcporter globally alongside openclaw in the deps stage; adds `/usr/local/bin/mcporter` symlink in runtime stage
- Bakes `/app/mcporter.json` into the image registering `limbo-vault` stdio server; entrypoint exports `MCPORTER_CONFIG` before gateway start
- Updates `workspace/TOOLS.md` and `workspace/AGENTS.md` with `mcporter call limbo-vault.<tool>` CLI syntax for all 4 vault tools

## Test Plan

- [ ] `docker build` succeeds with no errors on mcporter install or symlink
- [ ] Inside running container: `mcporter list limbo-vault` shows all 4 tools
- [ ] `mcporter call limbo-vault.vault_write_note id=test-mcporter title="test" type=claim description="test" content="test"` returns confirmation
- [ ] `mcporter call limbo-vault.vault_search query="test"` returns results
- [ ] `mcporter call limbo-vault.vault_read noteId="test-mcporter"` returns note
- [ ] Agent can invoke vault tools via shell in OpenClaw session

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>