### PR TITLE
chore: GitHub CI/CD workflows and branching strategy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,46 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main, staging]
+  push:
+    branches: [staging]
+
+jobs:
+  docker-build:
+    name: Docker Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  mcp-server-check:
+    name: MCP Server
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: mcp-server/package-lock.json
+
+      - name: Install dependencies
+        working-directory: mcp-server
+        run: npm ci
+
+      - name: Check for syntax errors in MCP server
+        working-directory: mcp-server
+        run: node --check index.js

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,56 @@
+name: Docker Publish
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    name: Build & Push to GHCR
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up QEMU (multi-arch)
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}
+            type=sha,prefix=sha-,format=short
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/docs/BRANCHING.md
+++ b/docs/BRANCHING.md
@@ -1,0 +1,57 @@
+# Branching Strategy
+
+## Branch Hierarchy
+
+```
+main (production) ← staging (pre-prod) ← feat/* fix/* chore/* (feature branches)
+```
+
+## Rules
+
+### `main`
+- **Protected.** Direct pushes are blocked.
+- Merges come exclusively from `staging` via PR.
+- Every merge triggers a Docker image publish to GHCR.
+
+### `staging`
+- Pre-production integration branch.
+- All feature branches target `staging` via PR.
+- CI runs on every PR and push to this branch.
+
+### Feature branches
+- Branch from `staging` (never from `main`).
+- Naming: `feat/`, `fix/`, `chore/` prefix.
+- Example: `feat/vault-search-improvements`, `fix/gateway-timeout`, `chore/update-deps`
+
+## Agent Workflow
+
+1. Start work: branch off `staging`
+   ```bash
+   git fetch origin staging
+   git checkout -b feat/your-feature origin/staging
+   ```
+
+2. Do the work, commit.
+
+3. Open PR targeting `staging`. CI must pass before merge.
+
+4. After staging is validated, a human or release manager opens a PR from `staging` → `main`.
+
+## CI/CD
+
+| Event | Workflow | What it does |
+|-------|----------|--------------|
+| PR to `staging` or `main` | `ci.yml` | Docker build + MCP server check |
+| Push to `staging` | `ci.yml` | Same as above |
+| Merge to `main` | `docker-publish.yml` | Build & push multi-arch image to GHCR |
+| Tag `v*` | `docker-publish.yml` | Build & push with semver tags |
+
+## Image Tags
+
+Produced by `docker-publish.yml` on merge to `main`:
+- `ghcr.io/tomasward1/limbo:main`
+- `ghcr.io/tomasward1/limbo:sha-<short-sha>`
+
+On semver tags (`v1.2.3`):
+- `ghcr.io/tomasward1/limbo:1.2.3`
+- `ghcr.io/tomasward1/limbo:1`


### PR DESCRIPTION
## Summary

- Adds `ci.yml`: Docker build validation + MCP server syntax check, runs on PRs to `staging` and `main`
- Adds `docker-publish.yml`: multi-arch build & push to GHCR on merge to `main` or semver tag
- Adds `docs/BRANCHING.md`: agent workflow guide documenting the `main ← staging ← feat/fix/chore` flow

## Branch protection setup (post-merge)

After this merges to `staging` and then to `main`, apply:
- `main`: require PR, require `Docker Build` + `MCP Server` status checks, no direct push
- `staging`: require PR, no direct push

## Test plan

- [ ] CI workflow triggers on this PR (Docker build + MCP server check pass)
- [ ] After merge to staging, open PR staging → main and verify CI triggers again
- [ ] After merge to main, verify docker-publish triggers and image appears in GHCR

🤖 Generated with [Claude Code](https://claude.com/claude-code)