### PR TITLE
fix: correct OpenClaw gateway startup and config template

### DIFF
--- a/openclaw.json.template
+++ b/openclaw.json.template
@@ -1,42 +1,20 @@
 {
   "gateway": {
-    "host": "0.0.0.0",
-    "port": 18789
+    "mode": "local",
+    "port": 18789,
+    "bind": "loopback",
+    "auth": { "mode": "token" }
   },
-  "model": {
-    "provider": "${MODEL_PROVIDER}",
-    "name": "${MODEL_NAME}",
-    "apiKey": "${LLM_API_KEY}"
-  },
-  "integrations": {
-    "telegram": {
-      "enabled": "${TELEGRAM_ENABLED}",
-      "token": "${TELEGRAM_BOT_TOKEN}"
+  "agents": {
+    "defaults": {
+      "model": "${MODEL_PROVIDER}/${MODEL_NAME}",
+      "workspace": "/data/workspace"
     }
   },
-  "mcp": {
-    "servers": [
-      {
-        "name": "limbo-vault",
-        "command": "node",
-        "args": ["/app/mcp-server/index.js"],
-        "env": {
-          "VAULT_PATH": "/data/vault"
-        }
-      }
-    ]
-  },
-  "agent": {
-    "identityFile": "/app/workspace/IDENTITY.md",
-    "soulFile": "/app/workspace/SOUL.md",
-    "agentsFile": "/app/workspace/AGENTS.md",
-    "toolsFile": "/app/workspace/TOOLS.md",
-    "userFile": "/data/config/USER.md"
-  },
-  "data": {
-    "dbPath": "/data/db",
-    "logsPath": "/data/logs",
-    "backupsPath": "/data/backups",
-    "memoryPath": "/data/memory"
+  "channels": {
+    "telegram": {
+      "enabled": ${TELEGRAM_ENABLED},
+      "botToken": "${TELEGRAM_BOT_TOKEN}"
+    }
   }
 }

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -61,6 +61,16 @@ log "INFO  Migrations OK"
 export MCPORTER_CONFIG=/app/mcporter.json
 log "INFO  mcporter configured — MCPORTER_CONFIG=$MCPORTER_CONFIG"
 
+# ── Point OpenClaw at our rendered config ─────────────────────────────────────
+export OPENCLAW_CONFIG_PATH=/app/openclaw.json
+
+# ── Gateway auth token (generate if not pre-set) ─────────────────────────────
+if [ -z "${OPENCLAW_GATEWAY_TOKEN:-}" ]; then
+  OPENCLAW_GATEWAY_TOKEN="$(head -c 32 /dev/urandom | base64 | tr -d '=+/' | head -c 32)"
+  log "INFO  Generated OPENCLAW_GATEWAY_TOKEN (not pre-set)"
+fi
+export OPENCLAW_GATEWAY_TOKEN
+
 # ── Start OpenClaw gateway ────────────────────────────────────────────────────
-log "INFO  Starting OpenClaw gateway"
-exec openclaw serve --config /app/openclaw.json
+log "INFO  Starting OpenClaw gateway (token auth, loopback)"
+exec openclaw gateway run --port 18789 --bind loopback


### PR DESCRIPTION
## Summary

- **`openclaw serve` → `openclaw gateway run`**: `serve` doesn't exist in OpenClaw 2026.3.8 — container was exiting immediately on startup. Was reintroduced by the PR #3 merge reverting to main's version.
- **Rewrote `openclaw.json.template`** with schema validated by `openclaw config validate`. Previous template used entirely fictional config keys (from main's version). Replaced with correct keys: `gateway.mode/port/bind/auth`, `agents.defaults.model/workspace`, `channels.telegram.enabled/botToken`.
- **Added `OPENCLAW_CONFIG_PATH` export** in entrypoint so the rendered config is picked up.

## E2E Smoke Test Results (post-fix)

| Check | Result |
|-------|--------|
| Container starts healthy | ✅ |
| OpenClaw gateway responds | ✅ `openclaw health` returns agent + session info |
| MCP tools discoverable (stdio) | ✅ All 4 tools: `vault_search`, `vault_read`, `vault_write_note`, `vault_update_map` |
| `vault_write_note` creates file | ✅ Note written to `/data/vault` |
| `vault_search` finds it | ✅ Score-ranked result returned |
| `vault_read` returns it | ✅ Full frontmatter + body |

## Test plan
- [ ] Build Docker image: `docker build -t limbo:local .`
- [ ] Run: `docker run -p 127.0.0.1:18789:18789 -e ANTHROPIC_API_KEY=<key> limbo:local`
- [ ] Verify container logs show "listening on ws://127.0.0.1:18789"
- [ ] Run: `docker exec <container> openclaw health`

🤖 Generated with [Claude Code](https://claude.com/claude-code)