### PR TITLE
Add GHCR release workflow and pinned image tag strategy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,10 @@ LLM_API_KEY=
 # OpenAI / Codex:    codex-mini-latest  (or gpt-4o, o1, etc.)
 # MODEL_NAME=claude-sonnet-4-6
 
+# Docker image tag used by docker-compose.yml.
+# Keep pinned to a tested release tag for deterministic installs.
+# LIMBO_IMAGE_TAG=1.0.0
+
 # ── Telegram Integration (optional) ──────────────────────────────────────────
 
 # Enable Telegram bot integration

--- a/.github/workflows/release-ghcr.yml
+++ b/.github/workflows/release-ghcr.yml
@@ -1,0 +1,46 @@
+name: Release GHCR Image
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/tomasward1/limbo
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}
+            type=raw,value=latest
+
+      - name: Build and push multi-arch image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/README.md
+++ b/README.md
@@ -30,6 +30,33 @@ Limbo binds to `127.0.0.1:18789`. Connect via the OpenClaw gateway or Telegram b
 
 ---
 
+## Release Channel (GHCR)
+
+Stable deploys should use a pinned semver image tag via `LIMBO_IMAGE_TAG`.
+
+- Release workflow source: `.github/workflows/release-ghcr.yml`
+- Published tags per release tag `vX.Y.Z`:
+  - `ghcr.io/tomasward1/limbo:X.Y.Z`
+  - `ghcr.io/tomasward1/limbo:X`
+  - `ghcr.io/tomasward1/limbo:latest`
+
+Create a release tag:
+
+```sh
+git tag -a v1.0.0 -m "Limbo v1.0.0"
+git push origin v1.0.0
+```
+
+Verify public pull (no credentials):
+
+```sh
+docker logout ghcr.io
+docker manifest inspect ghcr.io/tomasward1/limbo:1.0.0
+docker pull ghcr.io/tomasward1/limbo:1.0.0
+```
+
+---
+
 ## Environment Variables
 
 Copy `.env.example` to `.env` and set:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   limbo:
-    image: ghcr.io/tomasward1/limbo:1
+    image: ghcr.io/tomasward1/limbo:${LIMBO_IMAGE_TAG:-1.0.0}
     restart: unless-stopped
     ports:
       - "127.0.0.1:18789:18789"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -144,12 +144,14 @@ fi
 
 # ─── Write .env ───────────────────────────────────────────────────────────────
 header "Writing /opt/limbo/.env..."
+LIMBO_IMAGE_TAG="${LIMBO_IMAGE_TAG:-1.0.0}"
 cat > /opt/limbo/.env <<EOF
 LLM_API_KEY=${LLM_API_KEY}
 MODEL_PROVIDER=${MODEL_PROVIDER}
 MODEL_NAME=${MODEL_NAME}
 TELEGRAM_ENABLED=${TELEGRAM_ENABLED}
 TELEGRAM_BOT_TOKEN=${TELEGRAM_BOT_TOKEN}
+LIMBO_IMAGE_TAG=${LIMBO_IMAGE_TAG}
 EOF
 chmod 600 /opt/limbo/.env
 ok ".env written."


### PR DESCRIPTION
## Summary
- add release workflow to publish GHCR tags on semver release tags
- pin deploys to `LIMBO_IMAGE_TAG` in compose/env for controlled rollouts
- document release tagging and anonymous pull verification in README
- update installer default image tag to `1.0.0`

## Verification
- `docker logout ghcr.io`
- `docker manifest inspect ghcr.io/tomasward1/limbo:1.0.0`
- `docker pull ghcr.io/tomasward1/limbo:1.0.0`

Observed:
- manifest index available publicly (`linux/amd64`, `linux/arm64`)
- pull succeeds anonymously
- digest: `sha256:19c8fec934dafe604105bb6ebc30f46cf8a21db902a276dfa7f3685e4bc1fa21`
