### PR TITLE
feat: add promote staging→main CI workflow (LIM-61)

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -1,0 +1,64 @@
+name: Promote staging to main
+
+on:
+  push:
+    branches: [staging]
+
+jobs:
+  promote:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Determine bump type from staging commits
+        id: bump
+        run: |
+          COMMITS=$(git log origin/main..origin/staging --pretty=format:"%s" 2>/dev/null || echo "")
+          echo "--- Commits on staging not on main ---"
+          echo "$COMMITS"
+
+          if echo "$COMMITS" | grep -qE "^feat(\(.+\))?!:|BREAKING CHANGE"; then
+            TYPE="feat!"
+          elif echo "$COMMITS" | grep -qE "^feat(\(.+\))?:"; then
+            TYPE="feat"
+          elif echo "$COMMITS" | grep -qE "^fix(\(.+\))?:"; then
+            TYPE="fix"
+          else
+            TYPE="chore"
+          fi
+          echo "type=$TYPE" >> "$GITHUB_OUTPUT"
+
+      - name: Check for existing PR
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          existing=$(gh pr list --base main --head staging --json number --jq '.[0].number // empty')
+          echo "pr_number=$existing" >> "$GITHUB_OUTPUT"
+
+      - name: Create PR to main
+        if: steps.check.outputs.pr_number == ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BUMP_TYPE: ${{ steps.bump.outputs.type }}
+        run: |
+          gh pr create \
+            --base main \
+            --head staging \
+            --title "${BUMP_TYPE}: promote staging to main" \
+            --body "Automated promotion PR from staging. Merge after CI passes."
+
+      - name: Update existing PR title
+        if: steps.check.outputs.pr_number != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BUMP_TYPE: ${{ steps.bump.outputs.type }}
+          PR_NUMBER: ${{ steps.check.outputs.pr_number }}
+        run: |
+          gh pr edit "$PR_NUMBER" \
+            --title "${BUMP_TYPE}: promote staging to main"


### PR DESCRIPTION
## Summary

Closes LIM-61. Adds `.github/workflows/promote.yml` — a workflow that automatically opens (or updates) a staging→main PR on every push to `staging`.

**Behavior:**
- Triggers on every push to `staging`
- Scans commits on `staging` not yet on `main`, derives the conventional commit bump type (`feat!`, `feat`, `fix`, `chore`)
- If no staging→main PR exists: creates one with title `{type}: promote staging to main`
- If a PR already exists: updates its title (idempotent — no duplicate PRs)

**Based on:** whoop-cli's promote.yml (same pattern, adapted for limbo)

## Test plan

- [ ] Push a `feat:` commit to staging → verify PR is opened with title `feat: promote staging to main`
- [ ] Push another commit → verify existing PR title updates, no duplicate PR created
- [ ] Push a `fix:` commit (no feat on staging) → title updates to `fix: promote staging to main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)