### PR TITLE
fix: add NODE_AUTH_TOKEN for npm publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -71,6 +71,8 @@ jobs:
       - name: Publish
         if: steps.bump.outputs.type != 'none'
         run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Commit version bump and tag
         if: steps.version.outputs.new_version != ''

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,26 @@
+# Dev and CI files
+.github/
+.worktrees/
+agents/
+docs/
+web/
+
+# Docker files (not needed for npm CLI)
+Dockerfile
+docker-compose.yml
+.dockerignore
+
+# Config and templates
+openclaw.json.template
+mcporter.json
+vercel.json
+.env*
+
+# Workspace (baked into Docker, not npm)
+workspace/
+
+# Internal files
+migrations/
+scripts/
+PROJECT.md
+CLAUDE.md


### PR DESCRIPTION
## Summary

- **Root cause**: npm OIDC trusted publishing (provenance) cannot create a brand-new package. The `limbo-ai` package doesn't exist on npmjs.org yet, so the PUT returns 404.
- **Fix**: Add `NODE_AUTH_TOKEN` env var from `NPM_TOKEN` GitHub secret to the publish step. This provides classic auth while preserving `--provenance` for supply chain transparency.
- **Bonus**: Add `.npmignore` to exclude agent configs, workflows, Docker files, and other non-CLI artifacts from the published tarball (was 48 files, now only the essentials).

## Manual step required

After merging, you need to add an `NPM_TOKEN` secret to the GitHub repo:

1. Go to [npmjs.com](https://www.npmjs.com) → Access Tokens → Generate New Token (Classic, type: Automation)
2. Go to GitHub repo → Settings → Secrets → Actions → New repository secret
3. Name: `NPM_TOKEN`, Value: the npm token from step 1

## Test plan

- [ ] Add `NPM_TOKEN` GitHub secret
- [ ] Merge PR to staging, then promote to main
- [ ] Verify publish workflow succeeds on next push to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)