### PR TITLE
chore: add .npmignore to trim published tarball

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,26 @@
+# Dev and CI files
+.github/
+.worktrees/
+agents/
+docs/
+web/
+
+# Docker files (not needed for npm CLI)
+Dockerfile
+docker-compose.yml
+.dockerignore
+
+# Config and templates
+openclaw.json.template
+mcporter.json
+vercel.json
+.env*
+
+# Workspace (baked into Docker, not npm)
+workspace/
+
+# Internal files
+migrations/
+scripts/
+PROJECT.md
+CLAUDE.md


### PR DESCRIPTION
## Summary

- Adds `.npmignore` to exclude CI, Docker, agent configs, workspace and docs from the published tarball
- Published package: 10 files / ~21 kB (down from 48 files / ~264 kB)
- No workflow changes — CI stays on OIDC Trusted Publishing

## What's included in the package

```
README.md
cli.js
mcp-server/index.js
mcp-server/package.json
mcp-server/package-lock.json
mcp-server/tools/read.js
mcp-server/tools/search.js
mcp-server/tools/update-map.js
mcp-server/tools/write.js
package.json
```

## Context

Supersedes #22 (which added `NODE_AUTH_TOKEN` to CI — taking a different approach per board direction).

The CI `publish.yml` already uses OIDC Trusted Publishing (`--provenance`, `id-token: write`). The `.npmignore` is the only missing piece on the code side.

**One manual step still required:** the `limbo-ai` package must be created on npmjs.com before CI can publish. Two options:
1. Run `npm publish --access public` locally once (after `npm login`) — creates the package, CI handles everything after
2. Configure Trusted Publisher on npmjs.com before the first push to main (no token required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)