### PR TITLE
feat(landing): wire waitlist forms to Google Sheets via Apps Script

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -756,20 +756,47 @@
   if (chatMockup) chatObserver.observe(chatMockup);
 
   // ── Waitlist form ──────────────────────────────────────────
+  var WAITLIST_SCRIPT_URL = 'https://script.google.com/macros/s/AKfycbzN7OPKpZtQ12kAc1iV-UwUnJrJwhB7eNxheBOqcC0kuakTunZFa0QIrtnmdwEn0TIo/exec';
+
   window.handleWaitlist = function(e, formId) {
     e.preventDefault();
     var form = document.getElementById(formId);
     var btn = form.querySelector('.waitlist-submit');
     var input = form.querySelector('.waitlist-input');
+    var email = input.value.trim();
+    var originalBtnHTML = btn.innerHTML;
+
     btn.disabled = true;
-    btn.innerHTML = state.lang === 'es' ? '¡Listo! ✓' : 'Done! ✓';
-    btn.style.background = '#3D8A5A';
-    input.value = '';
-    setTimeout(function() {
-      btn.disabled = false;
-      btn.style.background = '';
-      btn.innerHTML = state.lang === 'es' ? 'Unirse a la lista' : 'Join Waitlist';
-    }, 3000);
+    btn.innerHTML = state.lang === 'es' ? 'Enviando...' : 'Sending...';
+
+    var formData = new FormData();
+    formData.append('email', email);
+
+    fetch(WAITLIST_SCRIPT_URL, { method: 'POST', body: formData })
+      .then(function(res) { return res.json(); })
+      .then(function(result) {
+        if (result.status === 'success') {
+          btn.innerHTML = state.lang === 'es' ? '¡Listo! ✓' : 'Done! ✓';
+          btn.style.background = '#3D8A5A';
+          input.value = '';
+          setTimeout(function() {
+            btn.disabled = false;
+            btn.style.background = '';
+            btn.innerHTML = originalBtnHTML;
+          }, 3000);
+        } else {
+          throw new Error('Submission failed');
+        }
+      })
+      .catch(function() {
+        btn.innerHTML = state.lang === 'es' ? 'Error - Intentá de nuevo' : 'Error - Try again';
+        btn.style.background = '#ef4444';
+        setTimeout(function() {
+          btn.disabled = false;
+          btn.style.background = '';
+          btn.innerHTML = originalBtnHTML;
+        }, 3000);
+      });
   };
 
   // ── GitHub stars ───────────────────────────────────────────


### PR DESCRIPTION
handleWaitlist() now POSTs to the existing Google Apps Script endpoint instead of showing a fake success state. Both waitlistHero and waitlistFinal forms POST email to the Apps Script, which saves to the Waitlist + CRM sheets and sends a notification email to tomas@familiaward.com.ar.

- Add WAITLIST_SCRIPT_URL constant
- Capture email before clearing input
- POST via FormData (email appended manually — inputs lack name attr)
- Show "Enviando..." / "Sending..." loading state
- On success: green confirmation, reset after 3s
- On error: red state with "Intentá de nuevo", reset after 3s