### PR TITLE
fix: promote CI — use PAT fallback for PR creation

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -44,7 +44,11 @@ jobs:
       - name: Create PR to main
         if: steps.check.outputs.pr_number == ''
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # GITHUB_TOKEN cannot create PRs unless the repo setting
+          # "Allow GitHub Actions to create and approve pull requests" is enabled.
+          # Use a fine-grained PAT (LIMBO_PAT) with pull_requests:write + contents:read
+          # to bypass that restriction. See: Settings > Actions > General.
+          GH_TOKEN: ${{ secrets.LIMBO_PAT || secrets.GITHUB_TOKEN }}
           BUMP_TYPE: ${{ steps.bump.outputs.type }}
         run: |
           gh pr create \


### PR DESCRIPTION
## Root Cause

`promote.yml` was failing with:
```
pull request create failed: GraphQL: GitHub Actions is not permitted to create or approve pull requests
```

The workflow already had `pull-requests: write` in permissions, but GitHub has a **separate repo-level toggle** that also controls this:

> Settings → Actions → General → Workflow permissions → **Allow GitHub Actions to create and approve pull requests**

Previous runs succeeded because an existing PR (#18) was open (the "Update existing PR title" step ran instead of "Create PR to main"). After #18 merged, every new push to `staging` hits the create-PR code path and fails.

## Fix

Two paths to resolve — **pick one**:

### Option A — Enable the repo setting (simplest, no secrets needed)
1. Go to **Settings → Actions → General**
2. Under "Workflow permissions", check **"Allow GitHub Actions to create and approve pull requests"**
3. This branch is unnecessary — close it and you're done

### Option B — Add a PAT secret (this PR)
1. Create a **fine-grained PAT** at https://github.com/settings/personal-access-tokens
   - Repository access: `TomasWard1/limbo`
   - Permissions: `Pull requests: Read and write`, `Contents: Read`
2. Add it as repo secret `LIMBO_PAT` under **Settings → Secrets → Actions**
3. Merge this PR

The `GH_TOKEN: ${{ secrets.LIMBO_PAT || secrets.GITHUB_TOKEN }}` expression in the workflow will prefer the PAT if set, else fall back to GITHUB_TOKEN (which works if Option A is enabled).

## Test plan
- [ ] After applying either fix: push a commit to `staging` and verify the promote workflow creates/updates a PR successfully