### PR TITLE
fix: graceful skip when Vercel secrets are missing in deploy-landing

### DIFF
--- a/.github/workflows/deploy-landing.yml
+++ b/.github/workflows/deploy-landing.yml
@@ -32,27 +32,43 @@ jobs:
       - name: Install Vercel CLI
         run: npm install --global vercel@latest
 
+      - name: Validate Vercel secrets
+        id: vercel_secrets
+        shell: bash
+        run: |
+          missing=()
+          [ -n "${{ secrets.VERCEL_TOKEN }}" ] || missing+=("VERCEL_TOKEN")
+          [ -n "${{ secrets.VERCEL_ORG_ID }}" ] || missing+=("VERCEL_ORG_ID")
+          [ -n "${{ secrets.VERCEL_PROJECT_ID }}" ] || missing+=("VERCEL_PROJECT_ID")
+
+          if [ "${#missing[@]}" -gt 0 ]; then
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::Skipping Vercel deploy. Missing secrets: ${missing[*]}"
+          else
+            echo "ready=true" >> "$GITHUB_OUTPUT"
+          fi
+
       # Required once in GitHub repo settings:
       # - VERCEL_TOKEN: Personal/Team token with deploy access
       # - VERCEL_ORG_ID: Team/org id
       # - VERCEL_PROJECT_ID: Project id for this landing page
       - name: Pull Vercel environment (staging preview)
-        if: github.ref_name == 'staging'
+        if: github.ref_name == 'staging' && steps.vercel_secrets.outputs.ready == 'true'
         run: vercel pull --yes --environment=preview --token="${{ secrets.VERCEL_TOKEN }}" --cwd web
 
       - name: Deploy preview from staging
-        if: github.ref_name == 'staging'
+        if: github.ref_name == 'staging' && steps.vercel_secrets.outputs.ready == 'true'
         id: deploy_preview
         run: |
           DEPLOY_URL="$(vercel deploy --target preview --token="${{ secrets.VERCEL_TOKEN }}" --cwd web)"
           echo "deploy_url=${DEPLOY_URL}" >> "$GITHUB_OUTPUT"
 
       - name: Pull Vercel environment (production)
-        if: github.ref_name == 'main'
+        if: github.ref_name == 'main' && steps.vercel_secrets.outputs.ready == 'true'
         run: vercel pull --yes --environment=production --token="${{ secrets.VERCEL_TOKEN }}" --cwd web
 
       - name: Deploy production from main
-        if: github.ref_name == 'main'
+        if: github.ref_name == 'main' && steps.vercel_secrets.outputs.ready == 'true'
         id: deploy_production
         run: |
           DEPLOY_URL="$(vercel deploy --prod --token="${{ secrets.VERCEL_TOKEN }}" --cwd web)"
@@ -60,7 +76,9 @@ jobs:
 
       - name: Summary
         run: |
-          if [ "${GITHUB_REF_NAME}" = "main" ]; then
+          if [ "${{ steps.vercel_secrets.outputs.ready }}" != "true" ]; then
+            echo "Deploy skipped: missing required Vercel secrets."
+          elif [ "${GITHUB_REF_NAME}" = "main" ]; then
             echo "Production deploy: ${{ steps.deploy_production.outputs.deploy_url }}"
           else
             echo "Preview deploy: ${{ steps.deploy_preview.outputs.deploy_url }}"


### PR DESCRIPTION
## Summary

- Backports the `Validate Vercel secrets` guard from `main` to `staging`
- Without it, `vercel pull --token=""` hard-fails with exit 1 when `VERCEL_TOKEN`/`VERCEL_ORG_ID`/`VERCEL_PROJECT_ID` are not configured
- Now emits a `::warning::` and skips all deploy steps instead of failing CI

## Root cause

`staging` had the old version of `deploy-landing.yml` that directly calls `vercel pull --token="${{ secrets.VERCEL_TOKEN }}"`. When secrets aren't set, GitHub Actions resolves the expression to empty string — `--token=""` — causing Vercel CLI to exit 1.

`main` already had a `Validate Vercel secrets` step (added separately) that guards all deploy steps with `steps.vercel_secrets.outputs.ready == 'true'`. This PR brings `staging` in sync.

## Test plan

- [ ] Merge to staging and observe next push: workflow should emit `warning: Skipping Vercel deploy. Missing secrets: VERCEL_TOKEN VERCEL_ORG_ID VERCEL_PROJECT_ID` and pass
- [ ] Once Vercel secrets are added to repo settings, deploy should proceed normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)