### PR TITLE
Improve npx Limbo onboarding

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -348,6 +348,7 @@ async function selectMenu(question, options, lang) {
 
   return new Promise((resolve) => {
     let selectedIndex = 0;
+    let lastRenderLineCount = 0;
     const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
     readline.emitKeypressEvents(process.stdin, rl);
     const previousRawMode = process.stdin.isRaw;
@@ -361,9 +362,20 @@ async function selectMenu(question, options, lang) {
     }
 
     function draw() {
+      const output = renderMenu(question, options, selectedIndex, lang);
+      if (lastRenderLineCount > 0) {
+        readline.moveCursor(process.stdout, 0, -lastRenderLineCount);
+      }
+      for (let i = 0; i < lastRenderLineCount; i++) {
+        readline.clearLine(process.stdout, 0);
+        if (i < lastRenderLineCount - 1) readline.moveCursor(process.stdout, 0, 1);
+      }
+      if (lastRenderLineCount > 0) {
+        readline.moveCursor(process.stdout, 0, -Math.max(lastRenderLineCount - 1, 0));
+      }
       readline.cursorTo(process.stdout, 0);
-      readline.clearScreenDown(process.stdout);
-      process.stdout.write(`${renderMenu(question, options, selectedIndex, lang)}\n`);
+      process.stdout.write(output);
+      lastRenderLineCount = output.split('\n').length;
     }
 
     function onKeypress(_, key = {}) {


### PR DESCRIPTION
## Summary
- redesign the npx onboarding flow around language/provider/auth/model selection
- persist OpenClaw state/config and bridge subscription auth through OpenClaw commands
- remove image tag prompting, add gateway guidance when Telegram is disabled, and fix interactive menu redraw

## Testing
- node --check cli.js
- sh -n scripts/entrypoint.sh