### PR TITLE
Fix Vercel root rewrite for landing page

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,6 +2,10 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "rewrites": [
     {
+      "source": "/",
+      "destination": "/web/index.html"
+    },
+    {
       "source": "/(.*)",
       "destination": "/web/$1"
     }


### PR DESCRIPTION
## Summary
- route the site root explicitly to 
- keep existing asset and subpath rewrites under 

## Problem
Vercel was rewriting  to , which returned  instead of serving the landing page entrypoint.

## Testing
- not run locally
