### PR TITLE
fix: header button polish (LIM-81)

### DIFF
--- a/web/css/styles.css
+++ b/web/css/styles.css
@@ -216,18 +216,26 @@ button {
   align-items: center;
   gap: 8px;
   font-family: var(--font);
-  font-size: 16px;
+  font-size: 14px;
   font-weight: 600;
-  border-radius: var(--r-sm);
-  padding: 10px 20px;
+  letter-spacing: 0.01em;
+  border-radius: var(--r-pill);
+  padding: 8px 16px;
   background: var(--accent);
   color: var(--text);
-  border: 1px solid transparent;
-  transition: background-color 150ms ease;
+  border: 1px solid rgba(255,255,255,0.12);
+  box-shadow: 0 1px 4px rgba(232,132,108,0.35), inset 0 1px 0 rgba(255,255,255,0.1);
+  transition: background-color 150ms ease, box-shadow 150ms ease, transform 150ms ease;
   cursor: pointer;
 }
 .btn-nav:hover {
   background: var(--accent-hover);
+  box-shadow: 0 3px 10px rgba(232,132,108,0.4), inset 0 1px 0 rgba(255,255,255,0.1);
+  transform: translateY(-1px);
+}
+.btn-nav:active {
+  transform: translateY(0);
+  box-shadow: 0 1px 2px rgba(232,132,108,0.2), inset 0 1px 0 rgba(255,255,255,0.1);
 }
 
 /* ============================================================

--- a/web/index.html
+++ b/web/index.html
@@ -834,7 +834,7 @@
   function renderStars(n) {
     var el = document.getElementById('starCount');
     if (n > 0) {
-      el.innerHTML = '<span data-lang="en">&#9733; ' + n + ' stars</span><span data-lang="es">&#9733; ' + n + ' favoritos</span>';
+      el.innerHTML = '<span data-lang="en">' + n + ' stars</span><span data-lang="es">' + n + ' favoritos</span>';
     }
   }
 


### PR DESCRIPTION
## Summary

- **Duplicate star**: `renderStars()` was injecting `&#9733;` (Unicode ★) before the star count, causing a double star. The SVG `icon-star` in the badge markup already handles the visual — removed the redundant `&#9733;`
- **Nav GitHub button**: Upgraded `.btn-nav` from a plain flat square to a polished pill-shaped button matching the design language. Changes: pill border-radius, lighter 14px font, subtle rgba white border highlight, orange-tinted box-shadow with depth, hover lift + active press transitions

## Test plan
- [ ] Star badge shows single star icon + count (e.g. `★ 12 stars`), not double star
- [ ] Nav GitHub button has pill shape, orange glow on hover, lifts on hover
- [ ] No regression on other buttons (`.btn-primary`, `.btn-secondary` untouched)
- [ ] Mobile: star badge hidden at <768px (existing behavior unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)