### PR TITLE
feat: security hardening — container lockdown, secrets, tool policy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,7 +39,7 @@
 # Auto-approve and persist the first Telegram DM sender on first run.
 # This removes the manual "openclaw pairing approve ..." step for MVP onboarding.
 # Set to false to keep strict manual pairing.
-# TELEGRAM_AUTO_PAIR_FIRST_DM=true
+# TELEGRAM_AUTO_PAIR_FIRST_DM=false
 
 # Stable gateway token for OpenClaw-compatible clients.
 # OPENCLAW_GATEWAY_TOKEN=replace-me

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,8 @@ WORKDIR /build
 RUN apt-get update && apt-get install -y --no-install-recommends git ca-certificates && rm -rf /var/lib/apt/lists/* \
   && git config --global url."https://github.com/".insteadOf "ssh://git@github.com/"
 
-# Install OpenClaw and mcporter globally
-RUN npm install -g openclaw mcporter
+# Install OpenClaw and mcporter globally (pinned for reproducibility + CVE control)
+RUN npm install -g openclaw@2026.3.12 mcporter@0.7.3
 
 # Copy MCP server and install its deps
 COPY mcp-server/package.json mcp-server/package-lock.json* ./mcp-server/

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Managed automatically by `npx limbo-ai start`, stored in `~/.limbo/.env`.
 | `MODEL_NAME` | no | `claude-opus-4-6` | Model name (e.g. `claude-opus-4-6`, `claude-sonnet-4-6`, `gpt-5.4`) |
 | `TELEGRAM_ENABLED` | no | `false` | Enable Telegram bot integration |
 | `TELEGRAM_BOT_TOKEN` | no | — | Telegram bot token (required if `TELEGRAM_ENABLED=true`) |
-| `TELEGRAM_AUTO_PAIR_FIRST_DM` | no | `true` | Auto-approves the first Telegram DM sender and persists access (MVP-friendly onboarding) |
+| `TELEGRAM_AUTO_PAIR_FIRST_DM` | no | `false` | Auto-approves the first Telegram DM sender and persists access (must opt-in explicitly) |
 | `OPENCLAW_GATEWAY_TOKEN` | no | generated | Stable gateway token for OpenClaw-compatible clients |
 
 > \* API keys are required only for `AUTH_MODE=api-key`. Subscription auth uses OpenClaw auth profiles instead.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,109 @@
+# Security
+
+## Container Security Model
+
+Limbo runs inside a Docker container with the following hardening:
+
+- **Non-root user**: The `limbo` user (UID/GID created at build time) runs all processes
+- **Read-only filesystem**: Container root filesystem is immutable (`read_only: true`)
+- **No new privileges**: `no-new-privileges` seccomp flag prevents privilege escalation
+- **Capabilities dropped**: All Linux capabilities are dropped (`cap_drop: ALL`)
+- **Process limit**: PID limit of 200 prevents fork bombs
+- **Loopback binding**: Gateway only listens on `127.0.0.1` — not exposed to LAN
+- **Writable paths**: Only `/data` (volume), `/home/limbo/.openclaw` (volume), `/tmp` (tmpfs), and `/home/limbo/.npm` (tmpfs) are writable
+
+## What Agents Can Access
+
+Inside the container, the AI agent can:
+
+- Read and write vault notes in `/data/vault/` (via MCP tools only)
+- Execute MCP tools registered through mcporter (vault_search, vault_read, vault_write_note, vault_update_map)
+- Search the web and fetch URLs (`web_search`, `web_fetch` — enabled for recommendations, link previews, etc.)
+- Respond to Telegram messages (if enabled, with pairing required)
+- Make network requests to AI provider APIs (Anthropic, OpenAI, OpenRouter)
+
+## What Agents Cannot Do
+
+- **Execute shell commands**: `exec` tool is denied + set to `security: "deny"`
+- **Browse the web**: `browser` tool is denied
+- **Read/write arbitrary files**: `group:fs` is denied, `fs.workspaceOnly` enforced
+- **Modify gateway config**: `gateway` tool is denied
+- **Create scheduled jobs**: `cron` tool is denied
+- **Spawn sub-agents**: `sessions_spawn` and `sessions_send` are denied
+- **Use elevated mode**: `elevated.enabled: false`
+- **Escape the container**: Read-only root filesystem + all capabilities dropped
+- **Escalate privileges**: `no-new-privileges` seccomp flag
+- **Access host filesystem**: Only the bind-mounted vault directory is accessible
+- **Spawn unlimited processes**: PID limit of 200
+
+## OpenClaw Tool Policy
+
+The agent runs with `tools.profile: "messaging"` — the most restrictive built-in profile. On top of that:
+
+- **Allowed**: `web_search`, `web_fetch` (for link previews, shopping recommendations, general web queries)
+- **Denied**: `exec`, `browser`, `canvas`, `nodes`, `cron`, `gateway`, `sessions_spawn`, `sessions_send`, `process`, `image`, `group:automation`, `group:runtime`, `group:fs`
+- **Exec**: `security: "deny"`, `ask: "always"`
+- **Elevated mode**: disabled
+- **Filesystem**: workspace-only
+
+The agent can interact with users via messaging, access vault data through the MCP server, and search/fetch web content. It cannot execute commands, access the filesystem directly, modify the gateway config, or spawn sub-agents.
+
+## API Key Storage
+
+API keys are stored as Docker Compose secrets:
+
+- **Secret files**: `~/.limbo/secrets/` with `0600` permissions (user read/write only)
+- **Mounted at runtime**: `/run/secrets/<name>` inside the container (read-only, restricted permissions)
+- **Not in environment**: Secrets are scrubbed from the process environment before the gateway starts
+- **Not in `docker inspect`**: Docker secrets don't appear in container inspect output
+- **`.env` file**: Only contains non-sensitive configuration (model provider, model name, language, etc.)
+- **Exception**: `OPENCLAW_GATEWAY_TOKEN` remains in the process environment because the gateway process needs it to validate incoming WebSocket connections. All other secrets (API keys, bot tokens) are scrubbed before exec
+
+## OpenClaw Security
+
+Limbo uses OpenClaw in a **personal assistant trust model** (one trusted operator per gateway). Key settings:
+
+- `gateway.mode: "local"` — local operation only
+- `gateway.bind: "loopback"` — no network exposure
+- `gateway.auth.mode: "token"` — all WebSocket clients must authenticate
+- `session.dmScope: "per-channel-peer"` — DM sessions are isolated per sender (when using Telegram)
+- `dmPolicy: "pairing"` — unknown Telegram senders must be explicitly approved
+
+For more on OpenClaw's security model: https://docs.openclaw.ai/security
+
+## Network Access
+
+The container can make outbound HTTPS requests to:
+
+- AI provider APIs (api.anthropic.com, api.openai.com, openrouter.ai)
+- Telegram Bot API (api.telegram.org) — if Telegram is enabled
+- Arbitrary URLs via `web_search` and `web_fetch` tools (for user-requested link previews, recommendations, etc.)
+
+For stricter environments, Limbo supports an optional Squid proxy sidecar (`--hardened` flag) that restricts outbound traffic to an allowlist of AI provider domains only. Note: `--hardened` mode disables `web_fetch` functionality since the proxy blocks non-allowlisted domains.
+
+## Input Validation
+
+The MCP server applies the following protections:
+
+- **Path traversal**: All file operations resolve paths and verify they don't escape the vault directory
+- **ID sanitization**: Note and map IDs are restricted to alphanumeric characters, dashes, and underscores
+- **Search queries**: User input is always escaped (no raw regex execution) with a 200-character limit to prevent ReDoS
+
+## Known Limitations
+
+- **Prompt injection**: AI agents can be manipulated by carefully crafted input. The container sandbox limits blast radius, but agents may still misuse their available tools within the vault
+- **Vault data exposure**: Anything stored in vault notes is accessible to the agent. Do not store passwords, private keys, or other high-sensitivity secrets in notes
+- **Single trust boundary**: The container runs one agent with one set of credentials. All tools and data inside the container share the same trust level
+- **Web fetch exfiltration**: The agent can read vault notes and fetch arbitrary URLs. A successful prompt injection could theoretically exfiltrate vault data via crafted URLs. Mitigation: DM pairing limits who can trigger the bot, strong models resist injection, and API keys are stored in Docker secrets (not in the vault). Do not store high-sensitivity data in vault notes
+- **Outbound network**: The agent can reach any internet destination via `web_search`/`web_fetch`. Use `--hardened` mode for strict egress filtering (disables web_fetch)
+
+## Reporting Vulnerabilities
+
+If you discover a security vulnerability in Limbo:
+
+1. **Do not** open a public issue
+2. Email the maintainer directly (see repository contact info)
+3. Include: description, reproduction steps, affected version, and impact assessment
+4. We will acknowledge within 48 hours and work on a fix
+
+For vulnerabilities in OpenClaw itself, follow their responsible disclosure process at https://docs.openclaw.ai/security

--- a/cli.js
+++ b/cli.js
@@ -14,6 +14,7 @@ const readline = require('readline');
 
 const LIMBO_DIR = path.join(os.homedir(), '.limbo');
 const VAULT_DIR = path.join(LIMBO_DIR, 'vault');
+const SECRETS_DIR = path.join(LIMBO_DIR, 'secrets');
 const ENV_FILE = path.join(LIMBO_DIR, '.env');
 const COMPOSE_FILE = path.join(LIMBO_DIR, 'docker-compose.yml');
 const GHCR_IMAGE = 'ghcr.io/tomasward1/limbo';
@@ -64,12 +65,25 @@ const COMPOSE_CONTENT = `services:
   limbo:
     image: ${GHCR_IMAGE}:${DEFAULT_TAG}
     restart: unless-stopped
+    read_only: true
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    pids_limit: 200
+    tmpfs:
+      - /tmp:size=100M,noexec,nosuid,nodev
+      - /home/limbo/.npm:size=50M,noexec,nosuid,nodev
     ports:
       - "127.0.0.1:${PORT}:${PORT}"
     volumes:
       - limbo-data:/data
       - ./vault:/data/vault
       - limbo-openclaw-state:/home/limbo/.openclaw
+    secrets:
+      - llm_api_key
+      - telegram_bot_token
+      - gateway_token
     env_file:
       - .env
     environment:
@@ -85,6 +99,98 @@ const COMPOSE_CONTENT = `services:
       timeout: 10s
       retries: 3
       start_period: 15s
+
+secrets:
+  llm_api_key:
+    file: ./secrets/llm_api_key
+  telegram_bot_token:
+    file: ./secrets/telegram_bot_token
+  gateway_token:
+    file: ./secrets/gateway_token
+
+volumes:
+  limbo-data:
+  limbo-openclaw-state:
+`;
+
+// Hardened variant: adds Squid egress proxy sidecar with domain allowlist
+const COMPOSE_CONTENT_HARDENED = `services:
+  limbo:
+    image: ${GHCR_IMAGE}:${DEFAULT_TAG}
+    restart: unless-stopped
+    read_only: true
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    pids_limit: 200
+    tmpfs:
+      - /tmp:size=100M,noexec,nosuid,nodev
+      - /home/limbo/.npm:size=50M,noexec,nosuid,nodev
+    ports:
+      - "127.0.0.1:${PORT}:${PORT}"
+    volumes:
+      - limbo-data:/data
+      - ./vault:/data/vault
+      - limbo-openclaw-state:/home/limbo/.openclaw
+    secrets:
+      - llm_api_key
+      - telegram_bot_token
+      - gateway_token
+    env_file:
+      - .env
+    environment:
+      OPENCLAW_CONFIG_PATH: /home/limbo/.openclaw/openclaw.json
+      OPENCLAW_STATE_DIR: /home/limbo/.openclaw
+      HTTP_PROXY: http://squid:3128
+      HTTPS_PROXY: http://squid:3128
+      NO_PROXY: "127.0.0.1,localhost"
+    networks:
+      - internal
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - >-
+          node -e "const s=require('net').connect(${PORT},'127.0.0.1');const
+          done=(c)=>{try{s.destroy()}catch{};process.exit(c)};s.on('connect',()=>done(0));s.on('error',()=>done(1));setTimeout(()=>done(1),2000);"
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 15s
+
+  squid:
+    image: ubuntu/squid:latest
+    restart: unless-stopped
+    read_only: true
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    cap_add:
+      - NET_BIND_SERVICE
+    tmpfs:
+      - /var/spool/squid:size=50M
+      - /var/log/squid:size=10M
+      - /var/run:size=5M
+    networks:
+      - internal
+      - external
+    volumes:
+      - ./squid/squid.conf:/etc/squid/squid.conf:ro
+      - ./squid/allowed-domains.txt:/etc/squid/allowed-domains.txt:ro
+
+networks:
+  internal:
+    internal: true
+  external:
+
+secrets:
+  llm_api_key:
+    file: ./secrets/llm_api_key
+  telegram_bot_token:
+    file: ./secrets/telegram_bot_token
+  gateway_token:
+    file: ./secrets/gateway_token
 
 volumes:
   limbo-data:
@@ -116,7 +222,7 @@ const TEXT = {
     telegramQuestion: 'Want to speak to Limbo through Telegram?',
     telegramBotFatherSteps: [
       'To create a Telegram bot:',
-      '  1. Open Telegram and search for @BotFather',
+      '  1. Open @BotFather: https://t.me/BotFather',
       '  2. Send the command: /newbot',
       '  3. Choose a display name for your bot (e.g. "My Limbo")',
       '  4. Choose a username ending in "bot" (e.g. "my_limbo_bot")',
@@ -126,6 +232,7 @@ const TEXT = {
     ],
     telegramTokenSafe: 'Your token is stored locally in ~/.limbo/.env and never sent anywhere.',
     telegramTokenPrompt: '  Telegram bot token: ',
+    telegramAutoPairQuestion: 'Auto-approve the first Telegram DM? (Convenient but less secure)',
     yes: 'Yes',
     no: 'No',
     configuration: 'Configuration',
@@ -179,6 +286,7 @@ const TEXT = {
     helpStatus: 'Show container status',
     helpHelp: 'Show this help',
     helpReconfigure: 'Reconfigure auth and onboarding settings (use with start)',
+    securityNotice: 'Security notice: Limbo runs AI agents inside a Docker container with access to your API keys and vault data. The container can make network requests to AI provider APIs. Do not store sensitive secrets (passwords, private keys) in your vault notes.',
     unknownCommand: (cmd) => `Unknown command: ${cmd}`,
   },
   es: {
@@ -205,7 +313,7 @@ const TEXT = {
     telegramQuestion: 'Quieres hablar con Limbo por Telegram?',
     telegramBotFatherSteps: [
       'Para crear un bot de Telegram:',
-      '  1. Abri Telegram y busca @BotFather',
+      '  1. Abri @BotFather: https://t.me/BotFather',
       '  2. Manda el comando: /newbot',
       '  3. Elegí un nombre para tu bot (ej: "Mi Limbo")',
       '  4. Elegí un username que termine en "bot" (ej: "mi_limbo_bot")',
@@ -215,6 +323,7 @@ const TEXT = {
     ],
     telegramTokenSafe: 'Tu token se guarda localmente en ~/.limbo/.env y nunca se envia a ningun servidor externo.',
     telegramTokenPrompt: '  Telegram bot token: ',
+    telegramAutoPairQuestion: 'Auto-aprobar el primer DM de Telegram? (Conveniente pero menos seguro)',
     yes: 'Si',
     no: 'No',
     configuration: 'Configuracion',
@@ -268,6 +377,7 @@ const TEXT = {
     helpStatus: 'Muestra el estado del container',
     helpHelp: 'Muestra esta ayuda',
     helpReconfigure: 'Reconfigura auth y onboarding (usar con start)',
+    securityNotice: 'Aviso de seguridad: Limbo corre agentes de IA dentro de un container Docker con acceso a tus API keys y datos del vault. El container puede hacer requests a las APIs de los proveedores de IA. No guardes secretos sensibles (passwords, claves privadas) en las notas del vault.',
     unknownCommand: (cmd) => `Comando desconocido: ${cmd}`,
   },
 };
@@ -433,15 +543,35 @@ function normalizeConfig(cfg, existingEnv = {}) {
     LLM_API_KEY: cfg.apiKey || (cfg.keepExisting ? existingEnv.LLM_API_KEY || '' : ''),
     TELEGRAM_ENABLED: cfg.telegramEnabled || existingEnv.TELEGRAM_ENABLED || 'false',
     TELEGRAM_BOT_TOKEN: cfg.telegramToken || (cfg.keepExisting ? existingEnv.TELEGRAM_BOT_TOKEN || '' : ''),
-    TELEGRAM_AUTO_PAIR_FIRST_DM: existingEnv.TELEGRAM_AUTO_PAIR_FIRST_DM || 'true',
+    TELEGRAM_AUTO_PAIR_FIRST_DM: cfg.telegramAutoPair || existingEnv.TELEGRAM_AUTO_PAIR_FIRST_DM || 'false',
     OPENCLAW_GATEWAY_TOKEN: gatewayToken,
   };
 
   return base;
 }
 
+function writeSecretFile(name, value) {
+  fs.mkdirSync(SECRETS_DIR, { recursive: true, mode: 0o700 });
+  const filePath = path.join(SECRETS_DIR, name);
+  fs.writeFileSync(filePath, value || '', { mode: 0o600 });
+}
+
+function writeSecrets(cfg, existingEnv = {}) {
+  const normalized = normalizeConfig(cfg, existingEnv);
+  writeSecretFile('llm_api_key', normalized.LLM_API_KEY);
+  writeSecretFile('telegram_bot_token', normalized.TELEGRAM_BOT_TOKEN);
+  writeSecretFile('gateway_token', normalized.OPENCLAW_GATEWAY_TOKEN);
+}
+
+const SECRET_KEYS = new Set([
+  'LLM_API_KEY', 'OPENAI_API_KEY', 'ANTHROPIC_API_KEY',
+  'TELEGRAM_BOT_TOKEN', 'OPENCLAW_GATEWAY_TOKEN',
+]);
+
 function writeEnv(cfg, existingEnv = {}) {
+  writeSecrets(cfg, existingEnv);
   const content = Object.entries(normalizeConfig(cfg, existingEnv))
+    .filter(([key]) => !SECRET_KEYS.has(key))
     .map(([key, value]) => `${key}=${value}`)
     .join('\n') + '\n';
   fs.writeFileSync(ENV_FILE, content, { mode: 0o600 });
@@ -542,6 +672,7 @@ async function collectConfig(existingEnv = {}) {
   ], language);
 
   let telegramToken = '';
+  let telegramAutoPair = 'false';
   if (telegramChoice.value === 'true') {
     console.log('');
     TEXT[language].telegramBotFatherSteps.forEach((line) => console.log(`  ${c.dim}${line}${c.reset}`));
@@ -551,6 +682,11 @@ async function collectConfig(existingEnv = {}) {
       t(language, 'telegramTokenPrompt'),
       (value) => value ? { ok: true, value } : { ok: false, message: t(language, 'requiredField') },
     );
+    const autoPairChoice = await selectMenu(t(language, 'telegramAutoPairQuestion'), [
+      { label: t(language, 'no'), value: 'false' },
+      { label: t(language, 'yes'), value: 'true' },
+    ], language);
+    telegramAutoPair = autoPairChoice.value;
   }
 
   return {
@@ -562,21 +698,50 @@ async function collectConfig(existingEnv = {}) {
     apiKey,
     telegramEnabled: telegramChoice.value,
     telegramToken,
+    telegramAutoPair,
     gatewayToken: existingEnv.OPENCLAW_GATEWAY_TOKEN || generateGatewayToken(),
   };
 }
 
-function ensureComposeFile() {
+function ensureComposeFile(hardened = false) {
   fs.mkdirSync(LIMBO_DIR, { recursive: true });
   fs.mkdirSync(path.join(VAULT_DIR, 'notes'), { recursive: true });
   fs.mkdirSync(path.join(VAULT_DIR, 'maps'), { recursive: true });
-  fs.writeFileSync(COMPOSE_FILE, COMPOSE_CONTENT);
+  fs.mkdirSync(SECRETS_DIR, { recursive: true, mode: 0o700 });
+  // Ensure secret files exist (Docker Compose secrets require the files to be present)
+  for (const name of ['llm_api_key', 'telegram_bot_token', 'gateway_token']) {
+    const fp = path.join(SECRETS_DIR, name);
+    if (!fs.existsSync(fp)) fs.writeFileSync(fp, '', { mode: 0o600 });
+  }
+  if (hardened) {
+    // Copy squid config files for egress filtering
+    const squidDir = path.join(LIMBO_DIR, 'squid');
+    fs.mkdirSync(squidDir, { recursive: true });
+    const srcSquidDir = path.join(__dirname, 'squid');
+    for (const file of ['squid.conf', 'allowed-domains.txt']) {
+      const src = path.join(srcSquidDir, file);
+      const dest = path.join(squidDir, file);
+      if (fs.existsSync(src)) fs.copyFileSync(src, dest);
+    }
+  }
+  fs.writeFileSync(COMPOSE_FILE, hardened ? COMPOSE_CONTENT_HARDENED : COMPOSE_CONTENT);
+}
+
+function readSecretFile(name) {
+  const fp = path.join(SECRETS_DIR, name);
+  try { return fs.readFileSync(fp, 'utf8').trim(); } catch { return ''; }
 }
 
 function ensureGatewayToken(existingEnv) {
-  if (existingEnv.OPENCLAW_GATEWAY_TOKEN) return existingEnv.OPENCLAW_GATEWAY_TOKEN;
+  // Check secret file first, then legacy env
+  const fromFile = readSecretFile('gateway_token');
+  if (fromFile) return fromFile;
+  if (existingEnv.OPENCLAW_GATEWAY_TOKEN) {
+    writeSecretFile('gateway_token', existingEnv.OPENCLAW_GATEWAY_TOKEN);
+    return existingEnv.OPENCLAW_GATEWAY_TOKEN;
+  }
   writeEnv({ keepExisting: true }, existingEnv);
-  return parseEnvFile().OPENCLAW_GATEWAY_TOKEN;
+  return readSecretFile('gateway_token');
 }
 
 function pullOrBuildImage(lang) {
@@ -702,7 +867,8 @@ ${c.green}${c.bold}╚═══════════════════�
 async function cmdStart() {
   if (!hasDocker()) die(t('en', 'dockerMissing'));
 
-  ensureComposeFile();
+  const hardened = process.argv.includes('--hardened');
+  ensureComposeFile(hardened);
 
   const existingEnv = parseEnvFile();
   const alreadyHasEnv = fs.existsSync(ENV_FILE);
@@ -767,10 +933,12 @@ async function cmdStart() {
     ok(t(cfg.language, 'healthy'));
   }
 
+  console.log(`\n  ${c.yellow}⚠  ${t(cfg.language, 'securityNotice')}${c.reset}\n`);
+
   printSuccess({
     language: cfg.language,
     telegramEnabled: mergedEnv.TELEGRAM_ENABLED || cfg.telegramEnabled || 'false',
-  }, parseEnvFile().OPENCLAW_GATEWAY_TOKEN);
+  }, readSecretFile('gateway_token') || mergedEnv.OPENCLAW_GATEWAY_TOKEN);
 }
 
 function cmdStop() {
@@ -819,6 +987,7 @@ ${c.bold}Commands:${c.reset}
 
 ${c.bold}Flags:${c.reset}
   --reconfigure  Reconfigure auth and onboarding settings (use with start)
+  --hardened     Enable egress proxy (restricts outbound to AI provider APIs only)
 
 ${c.bold}Data directory:${c.reset} ${LIMBO_DIR}
 `);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,13 +1,27 @@
 services:
   limbo:
-    image: ghcr.io/tomasward1/limbo:latest
+    # This file is a development reference. The CLI generates a versioned copy at install time.
+    image: ghcr.io/tomasward1/limbo:1.0.0
     restart: unless-stopped
+    read_only: true
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    pids_limit: 200
+    tmpfs:
+      - /tmp:size=100M,noexec,nosuid,nodev
+      - /home/limbo/.npm:size=50M,noexec,nosuid,nodev
     ports:
       - "127.0.0.1:18789:18789"
     volumes:
       - limbo-data:/data
       - ./vault:/data/vault
       - limbo-openclaw-state:/home/limbo/.openclaw
+    secrets:
+      - llm_api_key
+      - telegram_bot_token
+      - gateway_token
     env_file:
       - .env
     environment:
@@ -23,6 +37,14 @@ services:
       timeout: 10s
       retries: 3
       start_period: 15s
+
+secrets:
+  llm_api_key:
+    file: ./secrets/llm_api_key
+  telegram_bot_token:
+    file: ./secrets/telegram_bot_token
+  gateway_token:
+    file: ./secrets/gateway_token
 
 volumes:
   limbo-data:

--- a/mcp-server/tools/read.js
+++ b/mcp-server/tools/read.js
@@ -1,5 +1,5 @@
 import { readFile, readdir, stat } from "fs/promises";
-import { join } from "path";
+import { join, resolve } from "path";
 
 const VAULT_PATH = process.env.VAULT_PATH || "/data/vault";
 const NOTES_DIR = join(VAULT_PATH, "notes");
@@ -76,6 +76,12 @@ export async function vaultRead(noteId) {
 
   const filePath = await findNote(safe);
   if (!filePath) return null;
+
+  // Defense-in-depth: ensure resolved path stays within vault
+  const resolved = resolve(filePath);
+  if (!resolved.startsWith(resolve(NOTES_DIR) + "/")) {
+    throw new Error("Path traversal detected");
+  }
 
   try {
     return await readFile(filePath, "utf8");

--- a/mcp-server/tools/update-map.js
+++ b/mcp-server/tools/update-map.js
@@ -1,5 +1,5 @@
 import { readFile, writeFile, mkdir } from "fs/promises";
-import { join } from "path";
+import { join, resolve } from "path";
 
 const VAULT_PATH = process.env.VAULT_PATH || "/data/vault";
 const MAPS_DIR = join(VAULT_PATH, "maps");
@@ -71,7 +71,10 @@ export async function vaultUpdateMap(map, section, entries) {
   const safeMap = sanitizeName(map);
   await mkdir(MAPS_DIR, { recursive: true });
 
-  const filePath = join(MAPS_DIR, `${safeMap}.md`);
+  const filePath = resolve(MAPS_DIR, `${safeMap}.md`);
+  if (!filePath.startsWith(resolve(MAPS_DIR) + "/")) {
+    throw new Error("Path traversal detected");
+  }
 
   let existing = "";
   try {

--- a/mcp-server/tools/write.js
+++ b/mcp-server/tools/write.js
@@ -1,5 +1,5 @@
 import { writeFile, mkdir } from "fs/promises";
-import { join } from "path";
+import { join, resolve } from "path";
 
 const VAULT_PATH = process.env.VAULT_PATH || "/data/vault";
 const NOTES_DIR = join(VAULT_PATH, "notes");
@@ -79,7 +79,10 @@ export async function vaultWriteNote(note) {
 
   const frontmatter = buildFrontmatter({ ...note, id: safe });
   const fileContent = `${frontmatter}\n\n${note.content}\n`;
-  const filePath = join(targetDir, `${safe}.md`);
+  const filePath = resolve(targetDir, `${safe}.md`);
+  if (!filePath.startsWith(resolve(NOTES_DIR) + "/")) {
+    throw new Error("Path traversal detected");
+  }
 
   await writeFile(filePath, fileContent, "utf8");
   return { id: safe, path: filePath };

--- a/openclaw.json.template
+++ b/openclaw.json.template
@@ -5,6 +5,34 @@
     "bind": "loopback",
     "auth": { "mode": "token" }
   },
+  "session": {
+    "dmScope": "per-channel-peer"
+  },
+  "tools": {
+    "profile": "messaging",
+    "allow": [
+      "web_search",
+      "web_fetch"
+    ],
+    "deny": [
+      "group:automation",
+      "group:runtime",
+      "group:fs",
+      "exec",
+      "browser",
+      "canvas",
+      "nodes",
+      "cron",
+      "gateway",
+      "sessions_spawn",
+      "sessions_send",
+      "process",
+      "image"
+    ],
+    "fs": { "workspaceOnly": true },
+    "exec": { "security": "deny", "ask": "always" },
+    "elevated": { "enabled": false }
+  },
   "agents": {
     "defaults": {
       "model": { "primary": "${MODEL_PROVIDER}/${MODEL_NAME}" },
@@ -14,7 +42,8 @@
   "channels": {
     "telegram": {
       "enabled": ${TELEGRAM_ENABLED},
-      "botToken": "${TELEGRAM_BOT_TOKEN}"
+      "botToken": "${TELEGRAM_BOT_TOKEN}",
+      "dmPolicy": "pairing"
     }
   }
 }

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -18,17 +18,30 @@ log() {
 
 log "INFO  Limbo container starting"
 
-# ── Validate required env vars ───────────────────────────────────────────────
+# ── Read Docker secrets (with env var fallback for backwards compat) ──────────
+read_secret() {
+  local file="/run/secrets/$1"
+  if [ -f "$file" ]; then
+    cat "$file"
+  else
+    echo ""
+  fi
+}
+
 # API key auth is optional now because OpenClaw can also use persisted auth profiles.
-# Keep the legacy LLM_API_KEY path for backwards compatibility.
-LLM_API_KEY="${LLM_API_KEY:-}"
+# Prefer Docker secrets, fall back to env vars for backwards compatibility.
+_secret_llm="$(read_secret llm_api_key)"
+_secret_telegram="$(read_secret telegram_bot_token)"
+_secret_gateway="$(read_secret gateway_token)"
+
+LLM_API_KEY="${_secret_llm:-${LLM_API_KEY:-}}"
 
 # ── Defaults ─────────────────────────────────────────────────────────────────
 MODEL_PROVIDER="${MODEL_PROVIDER:-anthropic}"
 MODEL_NAME="${MODEL_NAME:-claude-opus-4-6}"
 TELEGRAM_ENABLED="${TELEGRAM_ENABLED:-false}"
-TELEGRAM_BOT_TOKEN="${TELEGRAM_BOT_TOKEN:-}"
-TELEGRAM_AUTO_PAIR_FIRST_DM="${TELEGRAM_AUTO_PAIR_FIRST_DM:-true}"
+TELEGRAM_BOT_TOKEN="${_secret_telegram:-${TELEGRAM_BOT_TOKEN:-}}"
+TELEGRAM_AUTO_PAIR_FIRST_DM="${TELEGRAM_AUTO_PAIR_FIRST_DM:-false}"
 OPENAI_API_KEY="${OPENAI_API_KEY:-}"
 ANTHROPIC_API_KEY="${ANTHROPIC_API_KEY:-}"
 OPENCLAW_STATE_DIR="${OPENCLAW_STATE_DIR:-/home/limbo/.openclaw}"

--- a/squid/allowed-domains.txt
+++ b/squid/allowed-domains.txt
@@ -1,0 +1,4 @@
+.api.anthropic.com
+.api.openai.com
+.openrouter.ai
+.api.telegram.org

--- a/squid/squid.conf
+++ b/squid/squid.conf
@@ -1,0 +1,39 @@
+# Squid proxy config for Limbo egress filtering
+# Only allows HTTPS CONNECT to allowlisted domains
+
+# ACL: allowed destination domains
+acl allowed_domains dstdomain "/etc/squid/allowed-domains.txt"
+
+# ACL: SSL ports used by AI provider APIs
+acl SSL_ports port 443
+
+# Only allow CONNECT method (HTTPS tunneling)
+acl CONNECT method CONNECT
+
+# Only CONNECT (HTTPS tunneling) is allowed — deny plain HTTP
+http_access deny !CONNECT
+
+# Deny CONNECT to non-SSL ports
+http_access deny CONNECT !SSL_ports
+
+# Allow CONNECT to allowlisted domains only
+http_access allow CONNECT allowed_domains
+
+# Deny everything else
+http_access deny all
+
+# Listen on port 3128
+http_port 3128
+
+# Minimal logging (privacy)
+access_log none
+cache_log /dev/null
+
+# No caching — we're a pure forward proxy
+cache deny all
+
+# Suppress Squid version in headers
+httpd_suppress_version_string on
+
+# Visible hostname (internal only)
+visible_hostname limbo-proxy


### PR DESCRIPTION
## Summary

Defense-in-depth hardening for production readiness:

- **Container**: `read_only` filesystem, `cap_drop: ALL`, `no-new-privileges`, `pids_limit: 200`, tmpfs for `/tmp` and `.npm`
- **Secrets**: API keys moved from env vars to Docker secrets (`/run/secrets/`), env scrubbed before `exec`
- **OpenClaw tool policy**: `messaging` profile + explicit allow (`web_search`, `web_fetch`) + deny (`exec`, `browser`, `cron`, `gateway`, `group:fs`, `group:runtime`, etc.)
- **Session isolation**: `per-channel-peer` DM scope, Telegram `dmPolicy: "pairing"`
- **Input validation**: ReDoS protection (escaped queries, 200 char limit), path traversal guards (`resolve` + `startsWith`)
- **Telegram auto-pair**: default changed to `false` (opt-in)
- **Pinned deps**: OpenClaw `2026.3.12`, mcporter `0.7.3`
- **Squid egress proxy**: opt-in via `--hardened` flag (domain allowlist for strict environments)
- **Security disclaimer**: shown in CLI onboarding (en/es)
- **SECURITY.md**: documents container model, tool policy, secrets, known limitations

## Files Changed

| File | Change |
|------|--------|
| `Dockerfile` | Pin OpenClaw + mcporter versions |
| `docker-compose.yml` | read_only, cap_drop, security_opt, pids_limit, tmpfs, secrets |
| `cli.js` | COMPOSE_CONTENT sync, secrets file creation, hardened mode, disclaimer, auto-pair prompt |
| `scripts/entrypoint.sh` | Read from Docker secrets, env scrub, auto-pair default false |
| `openclaw.json.template` | Tool policy (messaging + allow/deny), session isolation, DM pairing |
| `mcp-server/tools/read.js` | Path traversal defense-in-depth |
| `mcp-server/tools/write.js` | Path traversal defense-in-depth |
| `mcp-server/tools/update-map.js` | Path traversal defense-in-depth |
| `mcp-server/tools/search.js` | ReDoS protection (escape + length limit) |
| `squid/` | New — Squid proxy config + domain allowlist (for --hardened) |
| `SECURITY.md` | New — security model documentation |
| `.env.example`, `README.md` | Auto-pair default updated to false |

## Test Plan

- [ ] `docker compose up` succeeds with read_only + cap_drop — container starts, healthcheck passes
- [ ] Agent can read/write vault notes via MCP tools
- [ ] `docker exec limbo cat /proc/1/environ` does NOT show API keys (only OPENCLAW_GATEWAY_TOKEN)
- [ ] `docker inspect` does not show secrets in env
- [ ] Fresh install: auto-pair does NOT happen unless user explicitly opted in
- [ ] Security disclaimer shown during `limbo start`
- [ ] `vault_search` with long query (>200 chars) rejects
- [ ] Path traversal attempt (e.g. `../../etc/passwd`) is rejected by MCP tools
- [ ] `--hardened` flag creates Squid sidecar, `curl https://evil.com` from inside container fails

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>