### PR TITLE
fix(cli): add --tty to docker compose run for OpenAI auth + strip ANSI

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -809,8 +809,12 @@ function applyOpenClawConfig(cfg) {
   ok(t(cfg.language, 'configFlowDone'));
 }
 
+// Strip ANSI escape sequences so URL/text matching works on TTY output.
+const stripAnsi = (str) => str.replace(/\x1b\[[0-9;]*[A-Za-z]/g, '').replace(/\r/g, '');
+
 // Spawn OpenClaw auth with filtered output: extract OAuth URLs, suppress branding.
-// Uses async spawn so URLs appear in real-time (spawnSync would buffer until exit).
+// --tty is required so openclaw sees a TTY inside the container and runs the auth wizard.
+// We pipe stdout/stderr to filter content while the container gets a proper PTY allocation.
 function streamFilteredAuth(dockerArgs) {
   return new Promise((resolve) => {
     const proc = spawn('docker', dockerArgs, {
@@ -829,7 +833,8 @@ function streamFilteredAuth(dockerArgs) {
       for (const line of lines) emitLine(line);
     };
 
-    const emitLine = (line) => {
+    const emitLine = (rawLine) => {
+      const line = stripAnsi(rawLine);
       const urls = line.match(urlRe) || [];
       if (urls.length > 0) {
         for (const url of urls) {
@@ -870,8 +875,9 @@ async function runSubscriptionAuthFlow(cfg) {
 
   let exitCode;
   if (cfg.providerFamily === 'openai') {
-    // Stream output and extract OAuth URL so the user never sees "openclaw"
-    exitCode = await streamFilteredAuth(['compose', 'run', '--rm', '--entrypoint', 'openclaw', 'limbo', ...authArgs]);
+    // --tty allocates a PTY inside the container so openclaw's auth wizard runs correctly.
+    // We still pipe stdout/stderr to filter out branding and highlight the OAuth URL.
+    exitCode = await streamFilteredAuth(['compose', 'run', '--tty', '--rm', '--entrypoint', 'openclaw', 'limbo', ...authArgs]);
   } else {
     // Anthropic paste-token is interactive (user pastes a token); keep stdio inherited
     const authResult = runOpenClaw(authArgs);


### PR DESCRIPTION
## Problem

PR #63 introduced a regression: `openclaw models auth login` refuses to run when stdout is not a TTY, producing `Error: models auth login requires an interactive TTY`. The `streamFilteredAuth` function was spawning docker with piped stdout, which prevents Docker from allocating a pseudo-terminal for the container.

## Fix

- Add `--tty` to `docker compose run` so the container gets a PTY allocation and `openclaw` sees `process.stdout.isTTY === true`
- Add `stripAnsi()` to strip ANSI escape sequences and CR chars from PTY output before URL regex matching — TTY output contains control codes that would otherwise corrupt the URL pattern

## Test plan

- [ ] OpenAI subscription flow: auth URL appears without "models auth login requires an interactive TTY" error
- [ ] URL is displayed prominently, no "openclaw" branding visible
- [ ] Anthropic paste-token flow still works (unchanged code path)
- [ ] API-key flow unaffected (auth flow not called)

Fixes regression from #63. Closes LIM-90.

🤖 Generated with [Claude Code](https://claude.com/claude-code)