### PR TITLE
fix(cli): suppress all non-URL output in streamFilteredAuth

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -828,7 +828,8 @@ function streamFilteredAuth(dockerArgs) {
 
     const handleData = (data) => {
       buf += data.toString();
-      const lines = buf.split('\n');
+      // Split on \r\n, \n, or bare \r — TUIs use carriage returns for in-place redraws
+      const lines = buf.split(/\r?\n|\r/);
       buf = lines.pop(); // hold incomplete last line
       for (const line of lines) emitLine(line);
     };
@@ -836,18 +837,13 @@ function streamFilteredAuth(dockerArgs) {
     const emitLine = (rawLine) => {
       const line = stripAnsi(rawLine);
       const urls = line.match(urlRe) || [];
-      if (urls.length > 0) {
-        for (const url of urls) {
-          if (!seenUrls.has(url)) {
-            seenUrls.add(url);
-            console.log(`\n  ${c.cyan}${c.bold}→  ${url}${c.reset}\n`);
-          }
+      // Whitelist-only: only emit URLs — everything else is branding or TUI chrome
+      for (const url of urls) {
+        if (!seenUrls.has(url)) {
+          seenUrls.add(url);
+          console.log(`\n  ${c.cyan}${c.bold}→  ${url}${c.reset}\n`);
         }
-        return;
       }
-      // Suppress lines that only contain internal gateway/runtime branding
-      if (/openclaw/i.test(line)) return;
-      if (line.trim()) console.log(`   ${line}`);
     };
 
     proc.stdout.on('data', handleData);


### PR DESCRIPTION
## Summary

- **Branding leak**: `streamFilteredAuth` had a blacklist filter (`/openclaw/i`) that missed OpenClaw's flavor phrases (e.g. "I'm the assistant your terminal demanded..."). Those lines passed through and printed verbatim.
- **Terminal corruption**: OpenClaw's TUI auth wizard emits cursor-movement ANSI codes and bare `\r` redraws. Buffer was only split on `\n`, so partial TUI frames got re-emitted into our terminal, scattering characters across the screen.

**Fix**: Switch to a whitelist-only approach — `emitLine` now only emits OAuth URLs and silently drops everything else. Also fix buffer splitting to handle bare `\r` (in addition to `\n`).

## Test plan

- [ ] Run `npx limbo start` (fresh install), choose OpenAI subscription auth
- [ ] Verify only the OAuth URL appears during auth step — no branding phrases, no scattered characters
- [ ] Verify URL is clickable and auth completes normally
- [ ] Run with Anthropic subscription — paste-token path is unaffected (uses inherited stdio, not `streamFilteredAuth`)

Fixes LIM-91

🤖 Generated with [Claude Code](https://claude.com/claude-code)