### PR TITLE
fix(cli): show OpenClaw prompts during auth (pass-through non-URL output)

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -842,14 +842,19 @@ function streamFilteredAuth(dockerArgs, onUrl = null) {
     const emitLine = (rawLine) => {
       const line = stripAnsi(rawLine);
       const urls = line.match(urlRe) || [];
-      // Whitelist-only: only emit URLs — everything else is branding or TUI chrome
-      for (const url of urls) {
-        if (!seenUrls.has(url)) {
-          seenUrls.add(url);
-          console.log(`\n  ${c.cyan}${c.bold}→  ${url}${c.reset}\n`);
-          if (onUrl) onUrl(url);
+      if (urls.length > 0) {
+        for (const url of urls) {
+          if (!seenUrls.has(url)) {
+            seenUrls.add(url);
+            console.log(`\n  ${c.cyan}${c.bold}→  ${url}${c.reset}\n`);
+            if (onUrl) onUrl(url);
+          }
         }
+        return; // don't double-print the line containing the URL
       }
+      // Suppress OpenClaw branding; show everything else (prompts, status, interactive questions)
+      if (/openclaw/i.test(line)) return;
+      if (line.trim()) console.log(`   ${line}`);
     };
 
     proc.stdout.on('data', handleData);


### PR DESCRIPTION
## Summary

- **Root cause (clarified):** The `streamFilteredAuth` whitelist-only output filter was suppressing ALL non-URL output from OpenClaw — including the interactive prompt asking the user to paste the OAuth callback URL back into the CLI. The user had no visual cue and no way to complete auth.
- Restore pass-through for non-URL, non-branding lines so prompts, status messages, and interactive input requests are visible
- URLs are still formatted cleanly; OpenClaw branding lines are still suppressed

**This is the second fix for LIM-94.** The first fix (PR #69, merged) added port mapping and browser auto-open. This fix ensures the callback URL prompt is actually visible when OpenClaw uses the manual paste flow.

## Test plan

- [ ] Run `npx limbo start`, choose OpenAI + subscription auth
- [ ] After browser opens, complete OAuth login
- [ ] Verify OpenClaw's callback URL prompt is visible in the terminal
- [ ] Paste callback URL → auth completes successfully

Closes [LIM-94](/LIM/issues/LIM-94)

🤖 Generated with [Claude Code](https://claude.com/claude-code)