### PR TITLE
fix(cli): complete VT100 ANSI stripping to prevent scattered auth output

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -813,8 +813,15 @@ function applyOpenClawConfig(cfg) {
   ok(t(cfg.language, 'configFlowDone'));
 }
 
-// Strip ANSI escape sequences so URL/text matching works on TTY output.
-const stripAnsi = (str) => str.replace(/\x1b\[[0-9;]*[A-Za-z]/g, '').replace(/\r/g, '');
+// Strip ANSI/VT100 escape sequences so cursor-positioning codes don't scatter
+// characters across the terminal.  Handles:
+//   - CSI sequences: ESC [ <param bytes 0x30-0x3F> <intermediate 0x20-0x2F> <final 0x40-0x7E>
+//     (covers colour, cursor movement, erase, and private-mode sequences like \x1b[?25l)
+//   - Two-character ESC sequences: ESC <0x40-0x5F>  (e.g. ESC M, ESC =)
+const stripAnsi = (str) => str
+  .replace(/\x1b\[[0-?]*[ -/]*[@-~]/g, '')
+  .replace(/\x1b[@-Z\\-_]/g, '')
+  .replace(/\r/g, '');
 
 // Spawn OpenClaw auth with filtered output: extract OAuth URLs, suppress branding.
 // --tty is required so openclaw sees a TTY inside the container and runs the auth wizard.


### PR DESCRIPTION
## Root Cause

`streamFilteredAuth` used `/\x1b\[[0-9;]*[A-Za-z]/g` to strip ANSI escape sequences. This regex misses **private-mode sequences** (e.g. `\x1b[?25l` — hide cursor) because `?` (0x3F) is not in the character class `[0-9;]`.

OpenClaw's OAuth TUI emits cursor-positioning codes with private parameters during the auth flow. These passed through unstripped into `console.log`, so the terminal interpreted them and placed each character at an absolute screen position — causing the scattered display seen in the screenshots.

## Fix

Updated `stripAnsi` to use the standards-based VT100 CSI pattern:

```
\x1b\[[0-?]*[ -/]*[@-~]
```

This covers **all** parameter byte combinations (0x30–0x3F, including `?`, digits, `;`) plus intermediate and final bytes. Added a separate pass for two-character ESC sequences as well.

The `\r?\n|\r` buffer split (already in place) handles TUI carriage-return redraws at the buffer level. After stripping, cursor-positioned characters are now concatenated into clean lines instead of scattered across the terminal.

## Test plan
- [ ] Run `npx limbo start` with OpenAI subscription auth — auth URL should display cleanly, no scattered characters in the terminal
- [ ] Verify URL is still extracted and printed in cyan with arrow prefix
- [ ] Run with Anthropic subscription — paste-token flow still works (uses `runOpenClaw` with inherited stdio, not `streamFilteredAuth`)

Fixes [LIM-95](/LIM/issues/LIM-95)

🤖 Generated with [Claude Code](https://claude.com/claude-code)