### PR TITLE
test(cli): unit tests for streamFilteredAuth auth output parsing

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -821,9 +821,16 @@ function applyOpenClawConfig(cfg) {
 // Covers private-mode sequences like \x1b[?25l (hide cursor) that the old [0-9;]* missed.
 const stripAnsi = (str) => str
   .replace(/\x1b\[[0-?]*[ -/]*[@-~]/g, '')  // CSI sequences (all parameter byte combos)
+  .replace(/\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)/g, '') // OSC sequences (must run before two-char ESC to claim \x1b])
   .replace(/\x1b[@-Z\\-_]/g, '')             // two-char ESC sequences
-  .replace(/\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)/g, '') // OSC sequences
   .replace(/\r/g, '');
+
+// Matches OAuth/browser URLs emitted by OpenClaw during auth flows.
+const AUTH_URL_RE = /https?:\/\/[^\s"'<>\]]+/g;
+
+// Matches lines consisting entirely of TUI chrome: spinner glyphs, box-drawing chars, and
+// clack/prompt decorations. Used to suppress animation frame scatter from OpenClaw TUI output.
+const TUI_CHROME_RE = /^[\s\u2500-\u257f\u2580-\u259f\u25a0-\u25ff\u2600-\u26ff◇◆●○◈→←↑↓⠀-\u28ff]*$/u;
 
 // Spawn OpenClaw auth with filtered output: extract OAuth URLs, suppress branding.
 // --tty is required so openclaw sees a TTY inside the container and runs the auth wizard.
@@ -836,7 +843,6 @@ function streamFilteredAuth(dockerArgs, onUrl = null) {
       stdio: ['inherit', 'pipe', 'pipe'],
     });
 
-    const urlRe = /https?:\/\/[^\s"'<>\]]+/g;
     const seenUrls = new Set();
     let buf = '';
 
@@ -850,7 +856,7 @@ function streamFilteredAuth(dockerArgs, onUrl = null) {
 
     const emitLine = (rawLine) => {
       const line = stripAnsi(rawLine);
-      const urls = line.match(urlRe) || [];
+      const urls = line.match(AUTH_URL_RE) || [];
       if (urls.length > 0) {
         for (const url of urls) {
           if (!seenUrls.has(url)) {
@@ -867,8 +873,7 @@ function streamFilteredAuth(dockerArgs, onUrl = null) {
       // OpenClaw's TUI writes animation frames separated by \r — after our \r-split, each
       // frame becomes a short line (often a single char). We filter these out so they don't
       // scatter across the terminal as individual console.log lines.
-      const tuiChrome = /^[\s\u2500-\u257f\u2580-\u259f\u25a0-\u25ff\u2600-\u26ff◇◆●○◈→←↑↓⠀-\u28ff]*$/u;
-      if (tuiChrome.test(line)) return;
+      if (TUI_CHROME_RE.test(line)) return;
       if (line.trim()) console.log(`   ${line}`);
     };
 
@@ -1093,24 +1098,29 @@ ${c.bold}Data directory:${c.reset} ${LIMBO_DIR}
 
 // ─── Main ────────────────────────────────────────────────────────────────────
 
-const [,, cmd = 'start'] = process.argv;
+if (require.main === module) {
+  const [,, cmd = 'start'] = process.argv;
 
-(async () => {
-  switch (cmd) {
-    case 'start':
-    case 'install': await cmdStart(); break;
-    case 'stop':    cmdStop(); break;
-    case 'logs':    cmdLogs(); break;
-    case 'update':  cmdUpdate(); break;
-    case 'status':  cmdStatus(); break;
-    case 'help':
-    case '--help':
-    case '-h':      cmdHelp(); break;
-    default:
-      warn(t('en', 'unknownCommand', cmd));
-      cmdHelp();
-      process.exit(1);
-  }
-})().catch((err) => {
-  die(err.message || String(err));
-});
+  (async () => {
+    switch (cmd) {
+      case 'start':
+      case 'install': await cmdStart(); break;
+      case 'stop':    cmdStop(); break;
+      case 'logs':    cmdLogs(); break;
+      case 'update':  cmdUpdate(); break;
+      case 'status':  cmdStatus(); break;
+      case 'help':
+      case '--help':
+      case '-h':      cmdHelp(); break;
+      default:
+        warn(t('en', 'unknownCommand', cmd));
+        cmdHelp();
+        process.exit(1);
+    }
+  })().catch((err) => {
+    die(err.message || String(err));
+  });
+} else {
+  // Exported for unit testing — not part of the public CLI API.
+  module.exports = { stripAnsi, AUTH_URL_RE, TUI_CHROME_RE };
+}

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "@clack/prompts": "^1.1.0"
   },
   "scripts": {
-    "start": "node cli.js start"
+    "start": "node cli.js start",
+    "test": "node --test test/**/*.test.js"
   },
   "keywords": [
     "limbo",

--- a/test/cli-auth.test.js
+++ b/test/cli-auth.test.js
@@ -1,0 +1,185 @@
+// test/cli-auth.test.js
+// Unit tests for the streamFilteredAuth pure-logic functions exported from cli.js.
+// Run with: node --test test/cli-auth.test.js
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { stripAnsi, AUTH_URL_RE, TUI_CHROME_RE } = require('../cli.js');
+
+// ─── stripAnsi ────────────────────────────────────────────────────────────────
+
+test('stripAnsi: strips standard CSI sequences', () => {
+  assert.equal(stripAnsi('\x1b[32mgreen\x1b[0m'), 'green');
+  assert.equal(stripAnsi('\x1b[1;31mbold red\x1b[0m'), 'bold red');
+  assert.equal(stripAnsi('\x1b[2Kclear line'), 'clear line');
+});
+
+test('stripAnsi: strips ?-prefixed private-mode CSI sequences', () => {
+  // \x1b[?25l hide cursor, \x1b[?25h show cursor
+  assert.equal(stripAnsi('\x1b[?25lhello\x1b[?25h'), 'hello');
+  // \x1b[?2004h / \x1b[?2004l bracketed paste mode
+  assert.equal(stripAnsi('\x1b[?2004htext\x1b[?2004l'), 'text');
+});
+
+test('stripAnsi: strips two-char ESC sequences (0x40-0x5F range)', () => {
+  // ESC M (0x4D) — reverse index (cursor up with scroll)
+  assert.equal(stripAnsi('\x1bMline'), 'line');
+  // ESC E (0x45) — next line
+  assert.equal(stripAnsi('text\x1bEafter'), 'textafter');
+  // ESC ^ (0x5E) — privacy message (PM)
+  assert.equal(stripAnsi('before\x1b^after'), 'beforeafter');
+});
+
+test('stripAnsi: strips OSC sequences (BEL-terminated)', () => {
+  // OSC 0 ; title BEL — window title sequence
+  assert.equal(stripAnsi('\x1b]0;My Terminal Title\x07visible'), 'visible');
+});
+
+test('stripAnsi: strips OSC sequences (ST-terminated)', () => {
+  assert.equal(stripAnsi('\x1b]0;title\x1b\\visible'), 'visible');
+});
+
+test('stripAnsi: strips bare carriage returns', () => {
+  assert.equal(stripAnsi('line1\rline2'), 'line1line2');
+  assert.equal(stripAnsi('\r'), '');
+});
+
+test('stripAnsi: leaves plain text untouched', () => {
+  const plain = 'Hello, world! 123 !@#';
+  assert.equal(stripAnsi(plain), plain);
+});
+
+test('stripAnsi: handles empty string', () => {
+  assert.equal(stripAnsi(''), '');
+});
+
+test('stripAnsi: strips mixed sequences in one pass', () => {
+  // CSI (?25l hide cursor) + CSI (32m color) + OSC (window title) + bare CR
+  const input = '\x1b[?25l\x1b[32mProcessing\x1b[0m...\x1b]0;term\x07done\r';
+  assert.equal(stripAnsi(input), 'Processing...done');
+  // CSI + two-char ESC (M) mixed with real text
+  const input2 = '\x1b[1mbold\x1b[0m\x1bMnext';
+  assert.equal(stripAnsi(input2), 'boldnext');
+});
+
+// ─── TUI_CHROME_RE ────────────────────────────────────────────────────────────
+
+test('TUI_CHROME_RE: suppresses Braille spinner chars', () => {
+  // Common clack/openclaw spinner frames
+  for (const ch of ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏']) {
+    assert.equal(TUI_CHROME_RE.test(ch), true, `expected ${ch} to match TUI_CHROME_RE`);
+  }
+});
+
+test('TUI_CHROME_RE: suppresses box-drawing chars', () => {
+  assert.equal(TUI_CHROME_RE.test('─'), true);
+  assert.equal(TUI_CHROME_RE.test('│'), true);
+  assert.equal(TUI_CHROME_RE.test('┌┐└┘'), true);
+  assert.equal(TUI_CHROME_RE.test('═══'), true);
+});
+
+test('TUI_CHROME_RE: suppresses clack decoration chars', () => {
+  assert.equal(TUI_CHROME_RE.test('◇'), true);
+  assert.equal(TUI_CHROME_RE.test('●'), true);
+  assert.equal(TUI_CHROME_RE.test('◆'), true);
+  assert.equal(TUI_CHROME_RE.test('○'), true);
+});
+
+test('TUI_CHROME_RE: suppresses whitespace-only lines', () => {
+  assert.equal(TUI_CHROME_RE.test('   '), true);
+  assert.equal(TUI_CHROME_RE.test(''), true);
+  assert.equal(TUI_CHROME_RE.test('\t'), true);
+});
+
+test('TUI_CHROME_RE: suppresses mixed chrome lines (spinner + whitespace)', () => {
+  assert.equal(TUI_CHROME_RE.test('  ⠋  '), true);
+  assert.equal(TUI_CHROME_RE.test('◇  ─  ◇'), true);
+});
+
+test('TUI_CHROME_RE: passes lines with real text content', () => {
+  assert.equal(TUI_CHROME_RE.test('Please open this URL'), false);
+  assert.equal(TUI_CHROME_RE.test('Authenticating...'), false);
+  assert.equal(TUI_CHROME_RE.test('Press Enter to continue'), false);
+  assert.equal(TUI_CHROME_RE.test('Error: invalid token'), false);
+});
+
+test('TUI_CHROME_RE: passes lines starting with decoration but containing text', () => {
+  // clack prompts often have a leading decoration glyph followed by text
+  assert.equal(TUI_CHROME_RE.test('◇ Enter your API key'), false);
+  assert.equal(TUI_CHROME_RE.test('● Model selected: claude-opus-4-6'), false);
+});
+
+// ─── AUTH_URL_RE (URL extraction) ─────────────────────────────────────────────
+
+test('AUTH_URL_RE: detects http OAuth URLs', () => {
+  const line = 'Open this URL to authenticate: http://localhost:3000/oauth/callback?code=abc123';
+  const matches = line.match(AUTH_URL_RE);
+  assert.ok(matches, 'expected URL match');
+  assert.equal(matches[0], 'http://localhost:3000/oauth/callback?code=abc123');
+});
+
+test('AUTH_URL_RE: detects https OAuth URLs', () => {
+  const line = 'Visit https://auth.anthropic.com/oauth2/authorize?client_id=limbo&state=xyz to login';
+  const matches = line.match(AUTH_URL_RE);
+  assert.ok(matches, 'expected URL match');
+  assert.equal(matches[0], 'https://auth.anthropic.com/oauth2/authorize?client_id=limbo&state=xyz');
+});
+
+test('AUTH_URL_RE: does not match plain text without URL', () => {
+  const line = 'Waiting for authentication...';
+  const matches = line.match(AUTH_URL_RE);
+  assert.equal(matches, null);
+});
+
+test('AUTH_URL_RE: stops URL at whitespace', () => {
+  const line = 'URL: https://example.com/auth and then some text';
+  const matches = line.match(AUTH_URL_RE);
+  assert.ok(matches);
+  assert.equal(matches[0], 'https://example.com/auth');
+});
+
+test('AUTH_URL_RE: stops URL at angle bracket', () => {
+  const line = 'Go to <https://example.com/auth>';
+  const matches = line.match(AUTH_URL_RE);
+  assert.ok(matches);
+  assert.equal(matches[0], 'https://example.com/auth');
+});
+
+test('AUTH_URL_RE: extracts multiple URLs from a single line', () => {
+  const line = 'Primary: https://example.com/a Fallback: https://example.com/b';
+  const matches = line.match(AUTH_URL_RE);
+  assert.ok(matches);
+  assert.equal(matches.length, 2);
+  assert.equal(matches[0], 'https://example.com/a');
+  assert.equal(matches[1], 'https://example.com/b');
+});
+
+test('AUTH_URL_RE: URL deduplication — same URL seen twice is emitted once', () => {
+  // This tests the seenUrls Set logic conceptually — we verify that running AUTH_URL_RE
+  // against the same URL twice and filtering via a Set yields a single emission.
+  const url = 'https://auth.openai.com/oauth/callback?code=abc';
+  const lines = [
+    `Open: ${url}`,
+    `Retry: ${url}`,
+    'Different: https://example.com/other',
+  ];
+
+  const emitted = [];
+  const seenUrls = new Set();
+
+  for (const line of lines) {
+    const urls = line.match(AUTH_URL_RE) || [];
+    for (const u of urls) {
+      if (!seenUrls.has(u)) {
+        seenUrls.add(u);
+        emitted.push(u);
+      }
+    }
+  }
+
+  assert.equal(emitted.length, 2, 'duplicate URL should only be emitted once');
+  assert.equal(emitted[0], url);
+  assert.equal(emitted[1], 'https://example.com/other');
+});


### PR DESCRIPTION
## Summary

- Adds 23 unit tests for the pure functions in `streamFilteredAuth`: `stripAnsi`, `TUI_CHROME_RE`, and `AUTH_URL_RE`
- Uses Node.js built-in `node:test` — zero new dependencies
- Found and fixed a real bug: the main CLI IIFE was running at `require()` time because it wasn't guarded; wrapped it in `if (require.main === module)`
- Extracts inline regexes into named exported constants for testability

## Test coverage

| Area | Cases |
|------|-------|
| `stripAnsi` | standard CSI, `?`-prefixed private-mode CSI (`\x1b[?25l`), two-char ESC, OSC (BEL + ST), bare `\r`, plain text passthrough, mixed sequences |
| `TUI_CHROME_RE` | Braille spinners, box-drawing chars, clack decorations (`◇●`), whitespace-only; passthrough for lines with real text |
| `AUTH_URL_RE` | http/https detection, boundary stops (whitespace, angle bracket), multi-URL per line, deduplication via `Set` |

All 23 tests pass (`npm test`).

Closes LIM-97.

🤖 Generated with [Claude Code](https://claude.com/claude-code)