### PR TITLE
fix: secrets permission check and global limbo alias

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1001,6 +1001,34 @@ function ensureVolumePermissions() {
   ], { stdio: 'pipe' });
 }
 
+function installGlobalAlias() {
+  // Create a `limbo` shell wrapper so users don't have to type `npx limbo-ai` every time.
+  // Tries /usr/local/bin first (macOS, Linux with sudo), falls back to ~/.local/bin (no sudo).
+  const wrapper = '#!/bin/sh\nexec npx limbo-ai "$@"\n';
+  const candidates = [
+    path.join(os.homedir(), '.local', 'bin', 'limbo'),
+    '/usr/local/bin/limbo',
+  ];
+
+  for (const target of candidates) {
+    try {
+      // Skip if already installed and current
+      if (fs.existsSync(target)) {
+        const existing = fs.readFileSync(target, 'utf8');
+        if (existing.includes('limbo-ai')) return;
+      }
+      const dir = path.dirname(target);
+      if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(target, wrapper, { mode: 0o755 });
+      log(`Installed ${c.bold}limbo${c.reset} command → ${target}`);
+      return;
+    } catch {
+      // Permission denied — try next candidate
+    }
+  }
+  // Silent failure — not critical, user can still use npx limbo-ai
+}
+
 function isOomError(stderr) {
   return typeof stderr === 'string' && (
     stderr.includes('heap out of memory') ||
@@ -1622,6 +1650,8 @@ async function startContainerWithConfig(cfg, existingEnv, alreadyHasEnv) {
   }
 
   console.log(`\n  ${c.yellow}⚠  ${t(cfg.language, 'securityNotice')}${c.reset}\n`);
+
+  installGlobalAlias();
 
   printSuccess({
     language: cfg.language,

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -21,10 +21,10 @@ log "INFO  Limbo container starting"
 read_secret() {
   local docker_secret="/run/secrets/$1"
   local wizard_secret="/data/secrets/$1"
-  # Check Docker secrets first, but only if non-empty (empty files are placeholders)
-  if [ -f "$docker_secret" ] && [ -s "$docker_secret" ]; then
+  # Check Docker secrets first, but only if non-empty and readable
+  if [ -f "$docker_secret" ] && [ -s "$docker_secret" ] && [ -r "$docker_secret" ]; then
     cat "$docker_secret"
-  elif [ -f "$wizard_secret" ] && [ -s "$wizard_secret" ]; then
+  elif [ -f "$wizard_secret" ] && [ -s "$wizard_secret" ] && [ -r "$wizard_secret" ]; then
     cat "$wizard_secret"
   else
     echo ""


### PR DESCRIPTION
## Summary
- Add `-r` (readable) check to `read_secret()` in entrypoint.sh — prevents crash-loop when Docker mounts secrets with restricted permissions
- Install global `limbo` shell wrapper on successful start so users can type `limbo logs` instead of `npx limbo-ai logs`

## Test Plan
- [ ] Deploy to VPS, verify container starts without `Permission denied` on secrets
- [ ] Verify `limbo` command works after install (`limbo logs`, `limbo status`)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>