### PR TITLE
fix: quick tunnel 404 when named tunnel exists

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1075,7 +1075,7 @@ function createSetupTunnel(port, tunnelDomain) {
   // Default: quick tunnel (zero config, works for everyone)
   try {
     const logFile = path.join(LIMBO_DIR, 'cloudflared-setup.log');
-    const tunnelProc = spawn('cloudflared', ['tunnel', '--no-autoupdate', '--url', `http://localhost:${port}`], {
+    const tunnelProc = spawn('cloudflared', ['tunnel', '--no-autoupdate', '--config', '/dev/null', '--url', `http://localhost:${port}`], {
       detached: true,
       stdio: ['ignore', fs.openSync(logFile, 'w'), fs.openSync(logFile, 'a')],
     });


### PR DESCRIPTION
## Summary
- Quick tunnels pick up `~/.cloudflared/config.yml` by default, inheriting the named tunnel's catch-all `http_status:404` rule
- Fix: pass `--config /dev/null` to isolate the quick tunnel process

## Test Plan
- [ ] On VPS with existing named tunnel, run `npx limbo-ai start` — quick tunnel URL should return 200, not 404

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>