### PR TITLE
fix: secrets permissions and wizard fallback

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -179,10 +179,13 @@ function composeContent() {
 secrets:
   llm_api_key:
     file: ${SECRETS_DIR}/llm_api_key
+    mode: 0444
   telegram_bot_token:
     file: ${SECRETS_DIR}/telegram_bot_token
+    mode: 0444
   gateway_token:
     file: ${SECRETS_DIR}/gateway_token
+    mode: 0444
 
 volumes:
   limbo-data:
@@ -266,10 +269,13 @@ networks:
 secrets:
   llm_api_key:
     file: ${SECRETS_DIR}/llm_api_key
+    mode: 0444
   telegram_bot_token:
     file: ${SECRETS_DIR}/telegram_bot_token
+    mode: 0444
   gateway_token:
     file: ${SECRETS_DIR}/gateway_token
+    mode: 0444
 
 volumes:
   limbo-data:
@@ -1599,19 +1605,10 @@ async function cmdStart() {
     tunnel = await createSetupTunnel(PORT);
   }
 
-  if (wizardUrl) {
-    printWizardUrl(wizardUrl, tunnel);
-  } else {
-    const fallbackUrl = `http://127.0.0.1:${PORT}`;
-    console.log(`
-  ${c.green}${c.bold}Limbo is starting.${c.reset}
-
-  Open: ${c.cyan}${c.bold}${fallbackUrl}${c.reset}
-  ${c.dim}(may take a few seconds to be ready)${c.reset}
-
-  Logs: ${c.dim}limbo logs${c.reset}
-`);
-  }
+  // Always show the wizard URL with tunnel/SSH info, even if we couldn't
+  // extract the token-authenticated URL from logs.
+  const displayUrl = wizardUrl || `http://127.0.0.1:${PORT}`;
+  printWizardUrl(displayUrl, tunnel);
 }
 
 // Shared path for headless, CLI-prompt, and existing-config routes


### PR DESCRIPTION
## Summary
- Add `mode: 0444` to Docker secrets so they're readable by the `limbo` user inside the container (fixes crash loop on fresh VPS install)
- Always show tunnel URL and SSH forwarding instructions in wizard fallback, not just bare localhost

## Root cause
Docker Compose mounts secret files with the host file's uid/gid. On the VPS, this maps to `node:node` inside the container, but the process runs as `limbo` (uid 999). With `600` permissions, the `limbo` user can't read them → `cp` fails → `set -e` aborts → crash loop.

## Test plan
- [ ] Fresh install on VPS: container starts without crash loop
- [ ] Wizard shows tunnel URL or SSH instructions, never bare localhost

🤖 Generated with [Claude Code](https://claude.com/claude-code)