### PR TITLE
fix: remove mode from top-level secret definitions

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -182,13 +182,10 @@ function composeContent() {
 secrets:
   llm_api_key:
     file: ${SECRETS_DIR}/llm_api_key
-    mode: 0444
   telegram_bot_token:
     file: ${SECRETS_DIR}/telegram_bot_token
-    mode: 0444
   gateway_token:
     file: ${SECRETS_DIR}/gateway_token
-    mode: 0444
 
 volumes:
   limbo-data:
@@ -275,13 +272,10 @@ networks:
 secrets:
   llm_api_key:
     file: ${SECRETS_DIR}/llm_api_key
-    mode: 0444
   telegram_bot_token:
     file: ${SECRETS_DIR}/telegram_bot_token
-    mode: 0444
   gateway_token:
     file: ${SECRETS_DIR}/gateway_token
-    mode: 0444
 
 volumes:
   limbo-data:


### PR DESCRIPTION
## Summary
- Removed `mode: 0444` from top-level secret definitions in both `composeContent()` and `composeContentHardened()`
- Docker Compose only allows `mode` in service-level secret references (long syntax), not in top-level definitions
- Previous fix (PR #122) added mode to service-level correctly but didn't remove it from top-level

The `mode` remains correctly set at service-level where Docker Compose expects it.

## Test plan
- [x] `docker compose config` validates without errors
- [x] 34/34 migration tests pass
- [ ] VPS fresh install: secrets readable by container

🤖 Generated with [Claude Code](https://claude.com/claude-code)