### PR TITLE
fix: promote staging to main

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -182,13 +182,10 @@ function composeContent() {
 secrets:
   llm_api_key:
     file: ${SECRETS_DIR}/llm_api_key
-    mode: 0444
   telegram_bot_token:
     file: ${SECRETS_DIR}/telegram_bot_token
-    mode: 0444
   gateway_token:
     file: ${SECRETS_DIR}/gateway_token
-    mode: 0444
 
 volumes:
   limbo-data:
@@ -275,13 +272,10 @@ networks:
 secrets:
   llm_api_key:
     file: ${SECRETS_DIR}/llm_api_key
-    mode: 0444
   telegram_bot_token:
     file: ${SECRETS_DIR}/telegram_bot_token
-    mode: 0444
   gateway_token:
     file: ${SECRETS_DIR}/gateway_token
-    mode: 0444
 
 volumes:
   limbo-data:


### PR DESCRIPTION
## Summary
- Remove `mode: 0444` from top-level Docker Compose secret definitions
- Fixes Docker Compose validation error that blocked fresh installs

🤖 Generated with [Claude Code](https://claude.com/claude-code)