### PR TITLE
fix: secret file permissions for Docker Compose

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -159,12 +159,9 @@ function composeContent() {
       - ${VAULT_DIR}:/data/vault
       - limbo-zeroclaw-state:/home/limbo/.zeroclaw
     secrets:
-      - source: llm_api_key
-        mode: 0444
-      - source: telegram_bot_token
-        mode: 0444
-      - source: gateway_token
-        mode: 0444
+      - llm_api_key
+      - telegram_bot_token
+      - gateway_token
     env_file:
       - ${LIMBO_DIR}/.env
     environment:
@@ -218,12 +215,9 @@ function composeContentHardened() {
       - ${VAULT_DIR}:/data/vault
       - limbo-zeroclaw-state:/home/limbo/.zeroclaw
     secrets:
-      - source: llm_api_key
-        mode: 0444
-      - source: telegram_bot_token
-        mode: 0444
-      - source: gateway_token
-        mode: 0444
+      - llm_api_key
+      - telegram_bot_token
+      - gateway_token
     env_file:
       - ${LIMBO_DIR}/.env
     environment:
@@ -713,7 +707,10 @@ function normalizeConfig(cfg, existingEnv = {}) {
 function writeSecretFile(name, value) {
   fs.mkdirSync(SECRETS_DIR, { recursive: true, mode: 0o700 });
   const filePath = path.join(SECRETS_DIR, name);
-  fs.writeFileSync(filePath, value || '', { mode: 0o600 });
+  // Use 0644 so any container user can read the mounted file.
+  // Docker Compose file-based secrets ignore uid/gid/mode settings,
+  // so the host file permissions are what the container sees.
+  fs.writeFileSync(filePath, value || '', { mode: 0o644 });
 }
 
 function writeSecrets(cfg, existingEnv = {}) {
@@ -927,7 +924,7 @@ function ensureComposeFile(hardened = false) {
   // Ensure secret files exist (Docker Compose secrets require the files to be present)
   for (const name of ['llm_api_key', 'telegram_bot_token', 'gateway_token']) {
     const fp = path.join(SECRETS_DIR, name);
-    if (!fs.existsSync(fp)) fs.writeFileSync(fp, '', { mode: 0o600 });
+    if (!fs.existsSync(fp)) fs.writeFileSync(fp, '', { mode: 0o644 });
   }
   if (hardened) {
     // Copy squid config files for egress filtering

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -115,10 +115,13 @@ mkdir -p /data/vault/notes /data/vault/maps /data/config "$ZEROCLAW_STATE_DIR" "
 
 # Sync Docker secrets into ZeroClaw state dir.
 # Docker mounts secrets as read-only in /run/secrets/; we copy to a writable path.
+# Note: Docker Compose file-based secrets ignore uid/gid/mode settings,
+# so files may be owned by a different user. Use cp || true to tolerate
+# permission errors (e.g. during setup mode when secrets are placeholder files).
 for secret_name in gateway_token llm_api_key telegram_bot_token; do
   src="/run/secrets/$secret_name"
   dst="$ZC_SECRETS/$secret_name"
-  if [ -f "$src" ] && [ -s "$src" ]; then
+  if [ -f "$src" ] && [ -s "$src" ] && [ -r "$src" ]; then
     cp "$src" "$dst"
   fi
 done


### PR DESCRIPTION
## Summary
- Write secret files with `0644` permissions instead of `0600`
- Docker Compose file-based secrets ignore `uid`/`gid`/`mode` settings — files mount with host permissions
- Remove useless `mode: 0444` from service-level secret references (also ignored)
- Add `-r` (readable) check in entrypoint before `cp` to gracefully skip unreadable secrets
- Fixes container crash loop on fresh install (setup mode)

## Verified locally
- [x] Fresh install with `SSH_CONNECTION` (VPS simulation): token shown, tunnel URL shown, SSH instructions shown
- [x] Secret files created with `0644` on host
- [x] No `Permission denied` errors in container logs  
- [x] 34/34 migration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)