### PR TITLE
fix: remove provider prefix from model ID

### DIFF
--- a/config.toml.template
+++ b/config.toml.template
@@ -3,7 +3,7 @@
 # conditionally — see entrypoint.sh for details.
 
 default_provider = "${MODEL_PROVIDER}"
-default_model = "${ZEROCLAW_MODEL}"
+default_model = "${MODEL_NAME}"
 
 [gateway]
 host = "127.0.0.1"

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -178,18 +178,9 @@ else
     log "INFO  Subscription mode: remapped provider openai → openai-codex"
   fi
 
-  # Build the model ID for ZeroClaw config.
-  # OpenRouter model names already include the provider namespace (e.g.
-  # "anthropic/claude-sonnet-4-6"), so we must NOT prepend the provider again.
-  if [ "$MODEL_PROVIDER" = "openrouter" ]; then
-    ZEROCLAW_MODEL="$MODEL_NAME"
-  else
-    ZEROCLAW_MODEL="${MODEL_PROVIDER}/${MODEL_NAME}"
-  fi
-
   log "INFO  Generating ZeroClaw config from template"
-  export MODEL_PROVIDER ZEROCLAW_MODEL LIMBO_PORT
-  envsubst '$MODEL_PROVIDER $ZEROCLAW_MODEL $LIMBO_PORT' \
+  export MODEL_PROVIDER MODEL_NAME LIMBO_PORT
+  envsubst '$MODEL_PROVIDER $MODEL_NAME $LIMBO_PORT' \
     < /app/config.toml.template > "$ZEROCLAW_CONFIG_PATH"
 
   # Telegram: channel is enabled by section presence, not a boolean flag.

--- a/test/zeroclaw-migration.test.js
+++ b/test/zeroclaw-migration.test.js
@@ -74,7 +74,7 @@ test('config.toml.template does NOT contain unsupported sections', () => {
 
 test('config.toml.template uses envsubst variables', () => {
   const toml = read('config.toml.template');
-  const vars = ['${MODEL_PROVIDER}', '${ZEROCLAW_MODEL}', '${LIMBO_PORT}'];
+  const vars = ['${MODEL_PROVIDER}', '${MODEL_NAME}', '${LIMBO_PORT}'];
   for (const v of vars) {
     assert.ok(toml.includes(v), `Missing envsubst variable: ${v}`);
   }


### PR DESCRIPTION
## Summary
- Removes the `${MODEL_PROVIDER}/` prefix from `default_model` in `config.toml.template`
- ZeroClaw's `default_provider` field already identifies the provider — the model name should be bare
- Fixes 404 for Anthropic (`anthropic/claude-sonnet-4-6` rejected) and 400 for OpenRouter (double-prefixed)
- Simplifies entrypoint by removing the if/else ZEROCLAW_MODEL construction

## Test plan
- [x] All 133 tests pass locally
- [x] Verified on VPS: Anthropic subscription with `claude-sonnet-4-6` (no prefix) works correctly
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)