### PR TITLE
fix: upgrade ZeroClaw to v0.5.3 (official OAuth fix)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,23 +11,10 @@ COPY mcp-server/package.json mcp-server/package-lock.json* ./mcp-server/
 RUN cd mcp-server && npm ci --omit=dev
 
 # ──────────────────────────────────────────────
-# Stage 2: Build ZeroClaw from fork (OAuth fix)
-# Pin to our fork until zeroclaw-labs/zeroclaw#4053 is merged
+# Stage 2: ZeroClaw binary
+# v0.5.3 includes OAuth setup-token fix (#4053)
 # ──────────────────────────────────────────────
-FROM rust:1.94-slim AS zeroclaw-builder
-
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    pkg-config git ca-certificates \
-  && rm -rf /var/lib/apt/lists/*
-
-WORKDIR /build
-ARG ZEROCLAW_FORK_REF=fix/anthropic-oauth-headers
-RUN git clone --depth 1 --branch ${ZEROCLAW_FORK_REF} \
-    https://github.com/TomasWard1/zeroclaw.git . \
-  && sed -i 's/members = \[".", "crates\/robot-kit"\]/members = ["."]/' Cargo.toml \
-  && mkdir -p benches && echo "fn main() {}" > benches/agent_benchmarks.rs \
-  && cargo build --release \
-  && cp target/release/zeroclaw /usr/local/bin/zeroclaw
+FROM ghcr.io/zeroclaw-labs/zeroclaw:v0.5.3 AS zeroclaw
 
 # ──────────────────────────────────────────────
 # Stage 3: final runtime image
@@ -39,7 +26,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends gettext-base &&
   && groupadd -r limbo && useradd --create-home -r -g limbo limbo
 
 # Copy ZeroClaw binary
-COPY --from=zeroclaw-builder /usr/local/bin/zeroclaw /usr/local/bin/zeroclaw
+COPY --from=zeroclaw /usr/local/bin/zeroclaw /usr/local/bin/zeroclaw
 
 # App directories
 WORKDIR /app

--- a/test/zeroclaw-migration.test.js
+++ b/test/zeroclaw-migration.test.js
@@ -106,15 +106,11 @@ test('entrypoint.sh appends channels_config.telegram conditionally', () => {
 
 // ─── 4. Dockerfile references ZeroClaw, not OpenClaw ────────────────────────
 
-test('Dockerfile builds or pulls ZeroClaw binary', () => {
+test('Dockerfile pulls ZeroClaw binary from official image', () => {
   const df = read('Dockerfile');
-  // Accept either: pulling from official image OR building from source (fork)
-  const pullsOfficial = df.match(/FROM ghcr\.io\/zeroclaw-labs\/zeroclaw:\S+ AS zeroclaw/);
-  const buildsFromSource = df.includes('cargo build') && df.includes('zeroclaw');
-  assert.ok(pullsOfficial || buildsFromSource,
-    'Dockerfile must either pull ZeroClaw from ghcr.io or build from source');
-  assert.ok(df.includes('COPY --from=zeroclaw-builder /usr/local/bin/zeroclaw /usr/local/bin/zeroclaw')
-    || df.includes('COPY --from=zeroclaw /usr/local/bin/zeroclaw /usr/local/bin/zeroclaw'));
+  assert.ok(df.match(/FROM ghcr\.io\/zeroclaw-labs\/zeroclaw:\S+ AS zeroclaw/),
+    'Dockerfile must pull ZeroClaw from ghcr.io/zeroclaw-labs/zeroclaw');
+  assert.ok(df.includes('COPY --from=zeroclaw /usr/local/bin/zeroclaw /usr/local/bin/zeroclaw'));
 });
 
 test('Dockerfile does not reference openclaw or mcporter', () => {


### PR DESCRIPTION
## Summary
- Upgrade ZeroClaw from fork build-from-source to official `v0.5.3` prebuilt image
- Our upstream PR (zeroclaw-labs/zeroclaw#4053) was merged and released in v0.5.3
- Restores fast Docker builds (~seconds vs ~20min Rust compilation)

## What changed
- **Dockerfile**: Replaced Rust build stage with `FROM ghcr.io/zeroclaw-labs/zeroclaw:v0.5.3 AS zeroclaw`
- **test/zeroclaw-migration.test.js**: Restored original test that checks for official image

## Test plan
- [x] 133 Limbo tests pass
- [x] Verified commit `505024d` (our fix) is included in v0.5.3 tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)