### PR TITLE
fix: always bind to 127.0.0.1 instead of 0.0.0.0

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -154,7 +154,7 @@ function composeContent() {
       - /tmp:size=100M,noexec,nosuid,nodev
       - /home/limbo/.npm:size=50M,noexec,nosuid,nodev
     ports:
-      - "${isServerEnvironment() ? '0.0.0.0' : '127.0.0.1'}:${PORT}:${PORT}"
+      - "127.0.0.1:${PORT}:${PORT}"
     volumes:
       - limbo-data:/data
       - ${VAULT_DIR}:/data/vault
@@ -216,7 +216,7 @@ function composeContentHardened() {
       - /tmp:size=100M,noexec,nosuid,nodev
       - /home/limbo/.npm:size=50M,noexec,nosuid,nodev
     ports:
-      - "${isServerEnvironment() ? '0.0.0.0' : '127.0.0.1'}:${PORT}:${PORT}"
+      - "127.0.0.1:${PORT}:${PORT}"
     volumes:
       - limbo-data:/data
       - ${VAULT_DIR}:/data/vault
@@ -1504,7 +1504,7 @@ function printWizardUrl(url, tunnel) {
   // Extract token from the original URL
   const tokenMatch = url.match(/[?&]token=([^&\s]+)/);
   const token = tokenMatch ? tokenMatch[1] : '';
-  const localUrl = url.replace('0.0.0.0', '127.0.0.1');
+  const localUrl = url;
   const isSSH = !!(process.env.SSH_CONNECTION || process.env.SSH_CLIENT);
 
   console.log(`

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -263,8 +263,8 @@ else
   done
 
   if [[ -n "$SETUP_TOKEN" ]]; then
-    # Replace 0.0.0.0 with the actual server IP
-    SETUP_URL="${SETUP_TOKEN/0.0.0.0/$SERVER_IP}"
+    # Replace 127.0.0.1 with the actual server IP for remote access display
+    SETUP_URL="${SETUP_TOKEN/127.0.0.1/$SERVER_IP}"
     echo -e "  ${BOLD}Open this URL to complete setup:${NC}"
     echo ""
     echo -e "  ${CYAN}${SETUP_URL}${NC}"

--- a/setup-server/server.js
+++ b/setup-server/server.js
@@ -886,9 +886,9 @@ module.exports = {
 if (require.main === module) {
   const server = http.createServer(handleRequest);
 
-  server.listen(PORT, '0.0.0.0', () => {
+  server.listen(PORT, '127.0.0.1', () => {
     log(`Limbo Setup Wizard listening on port ${PORT}`);
-    log(`SETUP_URL=http://0.0.0.0:${PORT}/?token=${SETUP_TOKEN}`);
+    log(`SETUP_URL=http://127.0.0.1:${PORT}/?token=${SETUP_TOKEN}`);
     log('Share the URL above with the user to complete setup.');
   });
 


### PR DESCRIPTION
## Summary

- Always bind Docker port mapping to `127.0.0.1` instead of conditionally using `0.0.0.0` on server environments
- The `0.0.0.0` binding was never needed — both localhost.run tunnels and SSH port forwarding connect via loopback
- Updated setup-server to also listen on `127.0.0.1` inside the container

## Test plan

- [x] All 133 tests pass
- [x] Local Docker test: container starts with `127.0.0.1:18789->18789/tcp` binding
- [x] Setup wizard loads at `http://127.0.0.1:18789` (HTTP 200)
- [x] localhost.run tunnel connects successfully to loopback-bound port
- [ ] VPS deploy: verify `ss -tlnp` shows `127.0.0.1` binding

🤖 Generated with [Claude Code](https://claude.com/claude-code)