### PR TITLE
fix(install): remove gist dependency, use repo URLs

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -8,8 +8,8 @@ if [ -z "${BASH_VERSION:-}" ]; then
 fi
 set -euo pipefail
 
-INSTALLER_URL="https://gist.githubusercontent.com/TomasWard1/d130b8d34cc8eeb0527d045d06985396/raw/install.sh"
-COMPOSE_URL="https://gist.githubusercontent.com/TomasWard1/d130b8d34cc8eeb0527d045d06985396/raw/docker-compose.yml"
+INSTALLER_URL="https://raw.githubusercontent.com/TomasWard1/limbo/main/scripts/install.sh"
+COMPOSE_URL="https://raw.githubusercontent.com/TomasWard1/limbo/main/docker-compose.yml"
 
 # ─── Headless flags (optional — skip wizard for technical users) ─────────────
 HEADLESS_PROVIDER=""


### PR DESCRIPTION
## Summary
- `INSTALLER_URL` and `COMPOSE_URL` in `scripts/install.sh` were pointing to a GitHub gist
- Changed both to pull from the repo's main branch on `raw.githubusercontent.com`
- Removes the external gist as a single point of failure for new installs

## Test plan
- [ ] Run `curl -fsSL .../install.sh | bash` on a clean Ubuntu VPS and confirm docker-compose.yml downloads correctly
- [ ] Verify the installer self-reference URL in error messages is correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Paperclip <noreply@paperclip.ing>