### PR TITLE
feat: add --version / -v / version command

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -2078,6 +2078,9 @@ if (require.main === module) {
       case 'update':  cmdUpdate(); break;
       case 'status':  cmdStatus(); break;
       case 'config':  cmdConfig(); break;
+      case 'version':
+      case '--version':
+      case '-v':      console.log(require('./package.json').version); break;
       case 'help':
       case '--help':
       case '-h':      cmdHelp(); break;


### PR DESCRIPTION
## Summary
- Adds `limbo version`, `limbo --version`, and `limbo -v` commands
- Prints the package version from `package.json`

## Context
Currently there's no way to check the installed CLI version. Users (and beta testers) need this to verify they're running the right version after updates.

## Test plan
- [x] All 133 tests pass
- [x] `limbo --version`, `-v`, and `version` all print the version

🤖 Generated with [Claude Code](https://claude.com/claude-code)