### PR TITLE
fix: stale update banner and --reconfigure not clearing config

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1788,6 +1788,8 @@ function selfUpdateCli() {
       log(`Updating CLI: ${pkg.version} → ${latest}...`);
       execSync('npm install -g limbo-ai@latest', { stdio: 'inherit', timeout: 60000 });
       ok(`CLI updated to ${latest}.`);
+      // Clear update-check cache so notifyUpdate() won't show a stale banner
+      try { fs.unlinkSync(UPDATE_CHECK_FILE); } catch {}
     } else {
       // npx served a stale cached version — clear it
       warn(`CLI is outdated (${pkg.version} → ${latest}). npx served a cached version.`);
@@ -2068,7 +2070,7 @@ if (require.main === module) {
   const [,, cmd = 'start'] = process.argv;
 
   (async () => {
-    checkForUpdateInBackground();
+    if (cmd !== 'update') checkForUpdateInBackground();
 
     switch (cmd) {
       case 'start':

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -61,17 +61,9 @@ fi
 # CLI sets FORCE_SETUP_MODE=true via env_file when --reconfigure is used.
 # This is more reliable than running `docker compose run` to delete files,
 # which can fail silently due to volume permissions or Docker state.
-FORCE_DONE_MARKER="/data/.force-setup-done"
-
 if [ "${FORCE_SETUP_MODE:-}" = "true" ]; then
-  if [ ! -f "$FORCE_DONE_MARKER" ]; then
-    log "INFO  FORCE_SETUP_MODE requested — clearing config for reconfiguration"
-    rm -f /data/config/.env "$ZEROCLAW_CONFIG_PATH"
-    touch "$FORCE_DONE_MARKER"
-  fi
-else
-  # Normal start — clean up marker from previous reconfigure cycle
-  rm -f "$FORCE_DONE_MARKER"
+  log "INFO  FORCE_SETUP_MODE requested — clearing config for reconfiguration"
+  rm -f /data/config/.env "$ZEROCLAW_CONFIG_PATH"
 fi
 
 # ── Detect setup mode (no config yet → wizard will handle everything) ────────


### PR DESCRIPTION
## Summary
- **Update banner race condition**: `checkForUpdateInBackground()` spawns a detached process that re-writes `.update-check` after `cmdUpdate()` deletes it — skip background check for `update` command and clear cache after successful CLI self-update
- **`--reconfigure` silently failing**: `FORCE_DONE_MARKER` prevented config cleanup on repeat reconfigures when the container wasn't recreated between runs — remove the marker mechanism entirely, `FORCE_SETUP_MODE=true` env var is sufficient

## Context
Beta tester reported: after `limbo update` successfully updated CLI 1.23.5 → 1.23.6, the "Update available" banner still appeared. Then `limbo start --reconfigure` didn't enter setup mode — container loaded existing config instead of clearing it for the wizard.

## Test Plan
- [x] All 133 existing tests pass
- [ ] `limbo update` no longer shows stale banner after CLI self-update
- [ ] `limbo start --reconfigure` on a server with existing config enters setup wizard mode
- [ ] Repeat `--reconfigure` twice — second run should also clear config correctly

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>