### PR TITLE
fix: --reconfigure must always write FORCE_SETUP_MODE

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1667,23 +1667,20 @@ async function cmdStart() {
     return startContainerWithConfig(cfg, existingEnv, alreadyHasEnv);
   }
 
-  // ── Route: Wizard reconfigure (--reconfigure, no --cli) ───────────────────
-  if (reconfig && hasProviderConfig) {
+  // ── Route: Wizard reconfigure or fresh install ─────────────────────────────
+  // For --reconfigure: always write FORCE_SETUP_MODE so the entrypoint clears
+  // internal config. The host .env may not have MODEL_PROVIDER (wizard-configured
+  // users store config only inside the Docker volume), so we can't gate on
+  // hasProviderConfig — the user explicitly asked to reconfigure.
+  if (reconfig) {
     log('Resetting configuration for setup wizard...');
-    // Write minimal .env with FORCE_SETUP_MODE — the entrypoint will handle
-    // clearing internal config files. This is more reliable than running
-    // `docker compose run` to delete files inside the volume, which can fail
-    // silently due to permissions or Docker state issues.
     const minimalContent = `CLI_LANGUAGE=${existingEnv.CLI_LANGUAGE || 'en'}\nLIMBO_PORT=${PORT}\nFORCE_SETUP_MODE=true\n`;
     fs.writeFileSync(ENV_FILE, minimalContent, { mode: 0o600 });
-    // Keep gateway token secret intact
     ensureGatewayToken(existingEnv);
   }
 
-  // ── Route: Wizard (default for fresh install or wizard reconfigure) ───────
   log('Starting Limbo with setup wizard...');
   if (!alreadyHasEnv && !reconfig) {
-    // Fresh install only — reconfigure already wrote its own .env above
     writeMinimalEnv();
   }
 


### PR DESCRIPTION
## Summary
- The `--reconfigure` block was gated on `hasProviderConfig`, which checks the **host** `.env` for `MODEL_PROVIDER`
- Wizard-configured users (subscription mode) store config only inside the Docker volume at `/data/config/.env` — the host `.env` never gets `MODEL_PROVIDER`
- This meant `--reconfigure` silently skipped writing `FORCE_SETUP_MODE=true`, so the entrypoint never cleared internal config

## Fix
If the user explicitly passes `--reconfigure`, always write `FORCE_SETUP_MODE` regardless of host `.env` contents.

## Context
Follow-up to PR #157. The previous fix (removing `FORCE_DONE_MARKER`) was necessary but insufficient — the root cause was that the reconfigure path was never reached for wizard-configured users.

## Test Plan
- [x] All existing tests pass
- [ ] `limbo start --reconfigure` on wizard-configured server enters setup mode
- [ ] Fresh install still works (no `--reconfigure`, no existing config)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>