### PR TITLE
fix: setup wizard must bind 0.0.0.0 inside container

### DIFF
--- a/setup-server/server.js
+++ b/setup-server/server.js
@@ -886,7 +886,7 @@ module.exports = {
 if (require.main === module) {
   const server = http.createServer(handleRequest);
 
-  server.listen(PORT, '127.0.0.1', () => {
+  server.listen(PORT, '0.0.0.0', () => {
     log(`Limbo Setup Wizard listening on port ${PORT}`);
     log(`SETUP_URL=http://127.0.0.1:${PORT}/?token=${SETUP_TOKEN}`);
     log('Share the URL above with the user to complete setup.');


### PR DESCRIPTION
## Summary
- Reverts the `setup-server/server.js` portion of `ed433c0` (security hardening)
- Inside a Docker container, `127.0.0.1` only accepts loopback traffic — Docker's port mapping enters via the bridge IP, so connections were silently refused
- The real security layer is `127.0.0.1:PORT:PORT` in the compose file (host-side), which was already correct

## Context
Beta tester hit this: `--reconfigure` was fixed (PR #159), wizard started correctly, but both the tunnel URL and SSH port forwarding returned `ERR_EMPTY_RESPONSE`. `curl` from the host also returned empty, but `node` inside the container confirmed the wizard was responding. Classic Docker networking misunderstanding.

## Test Plan
- [x] All 133 tests pass
- [ ] `limbo start --reconfigure` → wizard accessible via SSH tunnel
- [ ] `limbo start` fresh install → wizard accessible via tunnel URL
- [ ] Port not accessible from external IPs (compose binds to 127.0.0.1 on host)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>