### PR TITLE
fix: subscription auth — secrets for Anthropic, auth-profiles for OpenAI

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -86,17 +86,24 @@ else
 fi
 
 # ── Validate and resolve API key ─────────────────────────────────────────────
-# Subscription mode uses OAuth tokens stored in ZeroClaw auth-profiles — no API key needed.
 # Setup mode skips validation entirely — the wizard will configure keys.
 AUTH_MODE="${AUTH_MODE:-api-key}"
 
 if [ "$SETUP_MODE" = "true" ]; then
   log "INFO  Setup mode — skipping API key validation"
 elif [ "$AUTH_MODE" = "subscription" ]; then
-  log "INFO  Subscription mode — using ZeroClaw auth profiles (no API key required)"
-  # Export any API keys that happen to exist, but don't require them
-  [ -n "$LLM_API_KEY" ] && export OPENAI_API_KEY="${OPENAI_API_KEY:-$LLM_API_KEY}"
-  [ -n "$LLM_API_KEY" ] && export ANTHROPIC_API_KEY="${ANTHROPIC_API_KEY:-$LLM_API_KEY}"
+  log "INFO  Subscription mode — credentials resolved from secrets"
+  # Subscription tokens are stored as secrets (same path as api-key mode).
+  # The wizard writes the token to secrets/llm_api_key during setup.
+  # read_secret already loaded it into LLM_API_KEY above.
+  case "$MODEL_PROVIDER" in
+    anthropic)
+      [ -n "$LLM_API_KEY" ] && export ANTHROPIC_API_KEY="${ANTHROPIC_API_KEY:-$LLM_API_KEY}"
+      ;;
+    openai|openai-codex)
+      [ -n "$LLM_API_KEY" ] && export OPENAI_API_KEY="${OPENAI_API_KEY:-$LLM_API_KEY}"
+      ;;
+  esac
 else
   # API-key mode: require LLM_API_KEY or provider-specific key
   case "$MODEL_PROVIDER" in

--- a/setup-server/server.js
+++ b/setup-server/server.js
@@ -229,9 +229,11 @@ function decodeJwtPayload(token) {
   return JSON.parse(Buffer.from(parts[1], 'base64url').toString());
 }
 
-// ZeroClaw auth-profiles.json — must match the structure used by the CLI
-// (cli.js buildAnthropicAuthProfile / buildCodexAuthProfile).
-// Path: ~/.zeroclaw/agents/main/agent/auth-profiles.json
+// ─── OpenAI Codex auth profiles ──────────────────────────────────────────────
+// OpenAI OAuth tokens expire and need refresh. ZeroClaw reads auth-profiles.json
+// for the refresh token and handles renewal automatically. This is ONLY needed
+// for OpenAI Codex — Anthropic tokens are static and stored as secrets instead.
+const AUTH_PROFILES_FILE = path.join(ZEROCLAW_STATE, 'auth-profiles.json');
 
 function buildCodexAuthProfile(profile) {
   const profileId = profile.email ? `openai-codex:${profile.email}` : 'openai-codex:default';
@@ -252,26 +254,6 @@ function buildCodexAuthProfile(profile) {
     usageStats: {},
   };
 }
-
-function buildAnthropicAuthProfile(token) {
-  return {
-    version: 1,
-    profiles: {
-      'anthropic:token': {
-        type: 'token',
-        provider: 'anthropic',
-        token,
-      },
-    },
-    order: { anthropic: ['anthropic:token'] },
-    lastGood: {},
-    usageStats: {},
-  };
-}
-
-// ZeroClaw resolves auth profiles from the state dir root: ~/.zeroclaw/auth-profiles.json
-// See: ZeroClaw src/auth/profiles.rs — state_dir.join("auth-profiles.json")
-const AUTH_PROFILES_FILE = path.join(ZEROCLAW_STATE, 'auth-profiles.json');
 
 function writeAuthProfiles(store) {
   fs.mkdirSync(ZEROCLAW_STATE, { recursive: true, mode: 0o700 });
@@ -557,6 +539,7 @@ async function exchangeOAuthCode(code, verifier, redirectUri) {
 function processOAuthTokens(tokenRes) {
   const jwt = decodeJwtPayload(tokenRes.access_token);
   const authClaim = jwt['https://api.openai.com/auth'] || {};
+  // Write auth profile for ZeroClaw's OAuth refresh flow
   const store = buildCodexAuthProfile({
     access: tokenRes.access_token,
     refresh: tokenRes.refresh_token,
@@ -565,6 +548,8 @@ function processOAuthTokens(tokenRes) {
     email: jwt.email || '',
   });
   writeAuthProfiles(store);
+  // Also write access token as secret for entrypoint to export
+  writeSecretFile('llm_api_key', tokenRes.access_token);
   return { email: jwt.email || '' };
 }
 
@@ -676,8 +661,9 @@ async function handleAnthropicToken(req, res) {
     return;
   }
 
-  const store = buildAnthropicAuthProfile(token);
-  writeAuthProfiles(store);
+  // Anthropic tokens are static (no refresh needed) — store as secret
+  writeSecretFile('llm_api_key', token);
+  log('Anthropic token written to secrets/llm_api_key');
   sendJSON(res, 200, { success: true });
 }
 
@@ -861,7 +847,6 @@ module.exports = {
   buildOAuthUrl,
   decodeJwtPayload,
   buildCodexAuthProfile,
-  buildAnthropicAuthProfile,
   handleRequest,
   _internals: {
     OPENAI_OAUTH,

--- a/test/setup-server.test.js
+++ b/test/setup-server.test.js
@@ -15,7 +15,6 @@ const {
   buildOAuthUrl,
   decodeJwtPayload,
   buildCodexAuthProfile,
-  buildAnthropicAuthProfile,
   handleRequest,
   _internals: { OPENAI_OAUTH },
 } = require('../setup-server/server.js');
@@ -194,24 +193,6 @@ describe('buildCodexAuthProfile', () => {
     const result = buildCodexAuthProfile(profile);
     const pid = 'openai-codex:default';
     assert.strictEqual(result.profiles[pid].accountId, '');
-  });
-});
-
-describe('buildAnthropicAuthProfile', () => {
-  it('builds correct structure', () => {
-    const result = buildAnthropicAuthProfile('sk-ant-test123');
-    assert.strictEqual(result.version, 1);
-    const pid = 'anthropic:token';
-    assert.ok(result.profiles[pid], 'profile entry exists');
-    assert.strictEqual(result.profiles[pid].provider, 'anthropic');
-    assert.strictEqual(result.profiles[pid].type, 'token');
-    assert.strictEqual(result.profiles[pid].token, 'sk-ant-test123');
-  });
-
-  it('order includes anthropic key', () => {
-    const result = buildAnthropicAuthProfile('sk-ant-xyz');
-    assert.ok(result.order.anthropic, 'order has anthropic key');
-    assert.deepStrictEqual(result.order.anthropic, ['anthropic:token']);
   });
 });
 


### PR DESCRIPTION
## Summary
- **Anthropic**: static tokens stored as `secrets/llm_api_key` — entrypoint exports as `ANTHROPIC_API_KEY`. No auth-profiles.json needed.
- **OpenAI Codex**: OAuth tokens need refresh — keep `auth-profiles.json` for ZeroClaw's refresh flow, plus write `access_token` as secret for the entrypoint.
- Remove `buildAnthropicAuthProfile` (was writing to a file nobody read)

## Root cause
ZeroClaw resolves credentials from env vars (`ANTHROPIC_API_KEY`), not `auth-profiles.json`. The wizard wrote tokens to auth-profiles.json, the entrypoint said "using auth profiles", but never exported the token as an env var.

## Test Plan
- [x] 131 tests pass
- [ ] `limbo start --reconfigure` with Anthropic subscription → bot responds
- [ ] OpenAI Codex OAuth flow still writes auth-profiles.json for refresh

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>