### PR TITLE
fix: align auth-profiles.json with ZeroClaw schema

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1297,38 +1297,45 @@ function writeAuthProfilesToDocker(store) {
 }
 
 function buildCodexAuthProfile(profile) {
-  const profileId = profile.email ? `openai-codex:${profile.email}` : 'openai-codex:default';
+  const profileName = profile.email || 'default';
+  const profileId = `openai-codex:${profileName}`;
+  const now = new Date().toISOString();
   return {
-    version: 1,
+    schema_version: 1,
+    updated_at: now,
+    active_profiles: { 'openai-codex': profileId },
     profiles: {
       [profileId]: {
-        type: 'oauth',
         provider: 'openai-codex',
-        access: profile.access,
-        refresh: profile.refresh,
-        expires: profile.expires,
-        accountId: profile.accountId,
+        profile_name: profileName,
+        kind: 'oauth',
+        account_id: profile.accountId || null,
+        access_token: profile.access,
+        refresh_token: profile.refresh,
+        expires_at: new Date(profile.expires).toISOString(),
+        created_at: now,
+        updated_at: now,
       },
     },
-    order: {},
-    lastGood: {},
-    usageStats: {},
   };
 }
 
 function buildAnthropicAuthProfile(token) {
+  const now = new Date().toISOString();
   return {
-    version: 1,
+    schema_version: 1,
+    updated_at: now,
+    active_profiles: { anthropic: 'anthropic:default' },
     profiles: {
-      'anthropic:token': {
-        type: 'token',
+      'anthropic:default': {
         provider: 'anthropic',
+        profile_name: 'default',
+        kind: 'token',
         token,
+        created_at: now,
+        updated_at: now,
       },
     },
-    order: { anthropic: ['anthropic:token'] },
-    lastGood: {},
-    usageStats: {},
   };
 }
 

--- a/setup-server/server.js
+++ b/setup-server/server.js
@@ -236,22 +236,26 @@ function decodeJwtPayload(token) {
 const AUTH_PROFILES_FILE = path.join(ZEROCLAW_STATE, 'auth-profiles.json');
 
 function buildCodexAuthProfile(profile) {
-  const profileId = profile.email ? `openai-codex:${profile.email}` : 'openai-codex:default';
+  const profileName = profile.email || 'default';
+  const profileId = `openai-codex:${profileName}`;
+  const now = new Date().toISOString();
   return {
-    version: 1,
+    schema_version: 1,
+    updated_at: now,
+    active_profiles: { 'openai-codex': profileId },
     profiles: {
       [profileId]: {
-        type: 'oauth',
         provider: 'openai-codex',
-        access: profile.access,
-        refresh: profile.refresh,
-        expires: profile.expires,
-        accountId: profile.accountId || '',
+        profile_name: profileName,
+        kind: 'oauth',
+        account_id: profile.accountId || null,
+        access_token: profile.access,
+        refresh_token: profile.refresh,
+        expires_at: new Date(profile.expires).toISOString(),
+        created_at: now,
+        updated_at: now,
       },
     },
-    order: {},
-    lastGood: {},
-    usageStats: {},
   };
 }
 

--- a/test/cli-auth.test.js
+++ b/test/cli-auth.test.js
@@ -264,7 +264,7 @@ test('parseClaudeSetupToken: special chars return null', () => {
 
 // ─── buildCodexAuthProfile ────────────────────────────────────────────────────
 
-test('buildCodexAuthProfile: correct structure with email', () => {
+test('buildCodexAuthProfile: correct ZeroClaw schema with email', () => {
   const profile = {
     email: 'user@example.com',
     access: 'access-token',
@@ -273,37 +273,43 @@ test('buildCodexAuthProfile: correct structure with email', () => {
     accountId: 'acct-123',
   };
   const result = buildCodexAuthProfile(profile);
-  assert.equal(result.version, 1);
+  assert.equal(result.schema_version, 1);
+  assert.ok(result.updated_at);
   const profileId = 'openai-codex:user@example.com';
+  assert.deepEqual(result.active_profiles, { 'openai-codex': profileId });
   assert.ok(result.profiles[profileId]);
-  assert.equal(result.profiles[profileId].type, 'oauth');
+  assert.equal(result.profiles[profileId].kind, 'oauth');
   assert.equal(result.profiles[profileId].provider, 'openai-codex');
-  assert.equal(result.profiles[profileId].access, 'access-token');
-  assert.equal(result.profiles[profileId].refresh, 'refresh-token');
-  assert.equal(result.profiles[profileId].expires, 1234567890);
-  assert.equal(result.profiles[profileId].accountId, 'acct-123');
+  assert.equal(result.profiles[profileId].profile_name, 'user@example.com');
+  assert.equal(result.profiles[profileId].access_token, 'access-token');
+  assert.equal(result.profiles[profileId].refresh_token, 'refresh-token');
+  assert.ok(result.profiles[profileId].expires_at);
+  assert.equal(result.profiles[profileId].account_id, 'acct-123');
 });
 
 test('buildCodexAuthProfile: default profileId without email', () => {
   const profile = { access: 'tok', refresh: 'ref', expires: 0 };
   const result = buildCodexAuthProfile(profile);
   assert.ok(result.profiles['openai-codex:default']);
+  assert.equal(result.profiles['openai-codex:default'].profile_name, 'default');
 });
 
 // ─── buildAnthropicAuthProfile ────────────────────────────────────────────────
 
-test('buildAnthropicAuthProfile: correct structure', () => {
+test('buildAnthropicAuthProfile: correct ZeroClaw schema', () => {
   const result = buildAnthropicAuthProfile('sk-ant-test-token');
-  assert.equal(result.version, 1);
-  assert.ok(result.profiles['anthropic:token']);
-  assert.equal(result.profiles['anthropic:token'].type, 'token');
-  assert.equal(result.profiles['anthropic:token'].provider, 'anthropic');
-  assert.equal(result.profiles['anthropic:token'].token, 'sk-ant-test-token');
+  assert.equal(result.schema_version, 1);
+  assert.ok(result.updated_at);
+  assert.ok(result.profiles['anthropic:default']);
+  assert.equal(result.profiles['anthropic:default'].kind, 'token');
+  assert.equal(result.profiles['anthropic:default'].provider, 'anthropic');
+  assert.equal(result.profiles['anthropic:default'].profile_name, 'default');
+  assert.equal(result.profiles['anthropic:default'].token, 'sk-ant-test-token');
 });
 
-test('buildAnthropicAuthProfile: order has anthropic key', () => {
+test('buildAnthropicAuthProfile: active_profiles has anthropic key', () => {
   const result = buildAnthropicAuthProfile('sk-ant-test');
-  assert.deepEqual(result.order, { anthropic: ['anthropic:token'] });
+  assert.deepEqual(result.active_profiles, { anthropic: 'anthropic:default' });
 });
 
 // ─── generatePKCE ─────────────────────────────────────────────────────────────

--- a/test/setup-server.test.js
+++ b/test/setup-server.test.js
@@ -166,7 +166,7 @@ describe('decodeJwtPayload', () => {
 });
 
 describe('buildCodexAuthProfile', () => {
-  it('builds correct structure with email', () => {
+  it('builds correct ZeroClaw schema with email', () => {
     const profile = {
       access: 'access-tok',
       refresh: 'refresh-tok',
@@ -175,16 +175,21 @@ describe('buildCodexAuthProfile', () => {
       email: 'test@example.com',
     };
     const result = buildCodexAuthProfile(profile);
-    assert.strictEqual(result.version, 1);
+    assert.strictEqual(result.schema_version, 1);
+    assert.ok(result.updated_at, 'has updated_at timestamp');
     const pid = 'openai-codex:test@example.com';
+    assert.deepStrictEqual(result.active_profiles, { 'openai-codex': pid });
     assert.ok(result.profiles[pid], 'profile entry exists');
     assert.strictEqual(result.profiles[pid].provider, 'openai-codex');
-    assert.strictEqual(result.profiles[pid].type, 'oauth');
-    assert.strictEqual(result.profiles[pid].access, 'access-tok');
-    assert.strictEqual(result.profiles[pid].refresh, 'refresh-tok');
+    assert.strictEqual(result.profiles[pid].profile_name, 'test@example.com');
+    assert.strictEqual(result.profiles[pid].kind, 'oauth');
+    assert.strictEqual(result.profiles[pid].access_token, 'access-tok');
+    assert.strictEqual(result.profiles[pid].refresh_token, 'refresh-tok');
+    assert.ok(result.profiles[pid].expires_at, 'has expires_at ISO string');
+    assert.strictEqual(result.profiles[pid].account_id, 'acct-1');
   });
 
-  it('builds correct structure without email (accountId empty)', () => {
+  it('builds correct structure without email (default profile)', () => {
     const profile = {
       access: 'a',
       refresh: 'r',
@@ -192,7 +197,9 @@ describe('buildCodexAuthProfile', () => {
     };
     const result = buildCodexAuthProfile(profile);
     const pid = 'openai-codex:default';
-    assert.strictEqual(result.profiles[pid].accountId, '');
+    assert.ok(result.profiles[pid], 'profile entry exists');
+    assert.strictEqual(result.profiles[pid].profile_name, 'default');
+    assert.strictEqual(result.profiles[pid].account_id, null);
   });
 });
 


### PR DESCRIPTION
## Summary
- auth-profiles.json was written with completely wrong field names — ZeroClaw's Rust serde deserializer rejected it with "Failed to parse auth profile store"
- Aligned `buildCodexAuthProfile` (setup-server + CLI) and `buildAnthropicAuthProfile` (CLI) to match `PersistedAuthProfiles` / `PersistedAuthProfile` structs from [ZeroClaw source](https://github.com/zeroclaw-labs/zeroclaw/blob/master/src/auth/profiles.rs)
- Key field renames: `version`→`schema_version`, `type`→`kind`, `access`→`access_token`, `refresh`→`refresh_token`, `expires`(ms)→`expires_at`(RFC3339), `accountId`→`account_id`, `order`→`active_profiles`, added required `profile_name`/`created_at`/`updated_at`

## Root cause
PR #165 changed fields from the original format to match "CLI format", but neither matched ZeroClaw's actual Rust structs. PR #172 removed Anthropic auth-profiles (correct) but left the broken OpenAI Codex format untested (`[ ] OpenAI Codex OAuth flow still writes auth-profiles.json`).

## Test plan
- [x] 147 tests pass (2 pre-existing eval-logging timeouts unrelated)
- [ ] OpenAI Codex subscription flow → bot responds on Telegram
- [ ] Anthropic subscription flow via CLI (`buildAnthropicAuthProfile`) → bot responds

🤖 Generated with [Claude Code](https://claude.com/claude-code)