### PR TITLE
feat(evals): add local eval dashboard

### DIFF
--- a/evals/dashboard/public/app.js
+++ b/evals/dashboard/public/app.js
@@ -1,0 +1,626 @@
+// === Limbo Eval Dashboard ===
+// Note: All data comes from local eval JSON files served by our own Node server.
+// All dynamic text is escaped via escapeHtml() before insertion.
+
+const state = {
+  latest: null,
+  baseline: null,
+  cases: [],
+  history: [],
+  currentView: 'overview',
+};
+
+// === API ===
+async function api(path) {
+  const res = await fetch(`/api/${path}`);
+  if (!res.ok) throw new Error(`API ${path}: ${res.status}`);
+  return res.json();
+}
+
+// === Init ===
+async function init() {
+  const [latest, baseline, cases, history] = await Promise.all([
+    api('latest'),
+    api('baseline'),
+    api('cases'),
+    api('history'),
+  ]);
+
+  state.latest = latest;
+  state.baseline = baseline;
+  state.cases = cases;
+  state.history = history;
+
+  // Build case lookup
+  state.caseMap = {};
+  cases.forEach(c => { state.caseMap[c.name] = c; });
+
+  setupNav();
+  renderOverview();
+  renderHistory();
+  renderCompareSelectors();
+  renderRubrics();
+  setupFilters();
+}
+
+// === Navigation ===
+function setupNav() {
+  document.querySelectorAll('.nav-tab').forEach(tab => {
+    tab.addEventListener('click', () => {
+      document.querySelectorAll('.nav-tab').forEach(t => t.classList.remove('active'));
+      document.querySelectorAll('.view').forEach(v => v.classList.remove('active'));
+      tab.classList.add('active');
+      const view = tab.dataset.view;
+      document.getElementById(`view-${view}`).classList.add('active');
+      state.currentView = view;
+    });
+  });
+}
+
+function showView(viewId) {
+  document.querySelectorAll('.nav-tab').forEach(t => t.classList.remove('active'));
+  document.querySelectorAll('.view').forEach(v => v.classList.remove('active'));
+  document.getElementById(`view-${viewId}`).classList.add('active');
+  const tab = document.querySelector(`[data-view="${viewId}"]`);
+  if (tab) tab.classList.add('active');
+  state.currentView = viewId;
+}
+
+// === Helpers ===
+function pct(n) { return `${Math.round(n * 100)}%`; }
+function statusOf(passRate) { return passRate >= 1 ? 'pass' : passRate > 0 ? 'partial' : 'fail'; }
+function statusIcon(passRate) { return passRate >= 1 ? '\u2713' : passRate > 0 ? '\u25D0' : '\u2717'; }
+
+function escapeHtml(str) {
+  if (!str) return '';
+  const div = document.createElement('div');
+  div.textContent = str;
+  return div.innerHTML;
+}
+
+function formatDate(ts) {
+  if (!ts) return '\u2014';
+  const d = new Date(ts);
+  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' }) +
+    ' ' + d.toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit' });
+}
+
+function shortDate(ts) {
+  if (!ts) return '';
+  const d = new Date(ts);
+  return `${d.getMonth() + 1}/${d.getDate()} ${d.getHours()}:${String(d.getMinutes()).padStart(2, '0')}`;
+}
+
+function barColor(rate) {
+  if (rate >= 0.9) return 'var(--green)';
+  if (rate >= 0.7) return 'var(--yellow)';
+  return 'var(--red)';
+}
+
+// === Safe DOM builders ===
+
+function createEl(tag, attrs, children) {
+  const el = document.createElement(tag);
+  if (attrs) {
+    Object.entries(attrs).forEach(([k, v]) => {
+      if (k === 'className') el.className = v;
+      else if (k === 'textContent') el.textContent = v;
+      else if (k.startsWith('on')) el.addEventListener(k.slice(2).toLowerCase(), v);
+      else if (k === 'style' && typeof v === 'object') Object.assign(el.style, v);
+      else el.setAttribute(k, v);
+    });
+  }
+  if (children) {
+    if (typeof children === 'string') el.textContent = children;
+    else if (Array.isArray(children)) children.forEach(c => { if (c) el.appendChild(c); });
+    else el.appendChild(children);
+  }
+  return el;
+}
+
+function difficultyPill(d) {
+  const el = document.createElement('span');
+  el.className = `pill pill-${escapeHtml(d)}`;
+  el.textContent = d;
+  return el;
+}
+
+function statusPill(s) {
+  const el = document.createElement('span');
+  el.className = `pill pill-${escapeHtml(s)}`;
+  el.textContent = s;
+  return el;
+}
+
+function tagPill(t) {
+  const el = document.createElement('span');
+  el.className = 'pill';
+  el.style.cssText = 'background: var(--cream); border: 1px solid var(--border-light); color: var(--text-gray)';
+  el.textContent = t;
+  return el;
+}
+
+// === Overview ===
+function renderOverview() {
+  const run = state.latest;
+  if (!run) {
+    const empty = document.getElementById('view-overview');
+    empty.replaceChildren(
+      createEl('div', { className: 'empty-state' }, [
+        createEl('h2', {}, 'No results yet'),
+        createEl('p', {}, 'Run node evals/cli.js run to generate results.'),
+      ])
+    );
+    return;
+  }
+
+  document.getElementById('overview-run-id').textContent =
+    `${run.id} \u2014 ${formatDate(run.timestamp)}`;
+
+  // Stats
+  const totalPassed = run.results.reduce((s, r) => s + r.passed, 0);
+  const totalAssertions = run.results.reduce((s, r) => s + r.total, 0);
+  const overallRate = totalAssertions ? totalPassed / totalAssertions : 0;
+  const casesFullPass = run.results.filter(r => r.passRate >= 1).length;
+  const casesFailed = run.results.filter(r => r.passRate < 1).length;
+
+  const statsEl = document.getElementById('overview-stats');
+  statsEl.replaceChildren(
+    buildStatCard('Pass Rate', pct(overallRate), statusOf(overallRate), `${totalPassed}/${totalAssertions} assertions`),
+    buildStatCard('Cases', String(run.results.length), 'neutral', `${casesFullPass} passed, ${casesFailed} with failures`),
+    buildStatCard('Full Pass', String(casesFullPass), 'pass', `${pct(casesFullPass / run.results.length)} of cases`),
+    buildStatCard('With Failures', String(casesFailed), casesFailed ? 'fail' : 'pass', casesFailed ? 'needs attention' : 'all clean'),
+  );
+
+  // Difficulty breakdown
+  const byDiff = {};
+  run.results.forEach(r => {
+    const caseDef = state.caseMap[r.case];
+    const diff = caseDef ? caseDef.difficulty : 'unknown';
+    if (!byDiff[diff]) byDiff[diff] = { passed: 0, total: 0, cases: 0 };
+    byDiff[diff].passed += r.passed;
+    byDiff[diff].total += r.total;
+    byDiff[diff].cases++;
+  });
+
+  const diffOrder = ['easy', 'medium', 'hard'];
+  const diffEl = document.getElementById('overview-difficulty');
+  diffEl.replaceChildren(...diffOrder.filter(d => byDiff[d]).map(d => {
+    const b = byDiff[d];
+    const rate = b.total ? b.passed / b.total : 0;
+    const card = createEl('div', { className: 'difficulty-card' });
+    const header = createEl('div', { className: 'difficulty-header' });
+    const label = createEl('span', { className: 'difficulty-label' });
+    label.appendChild(difficultyPill(d));
+    label.appendChild(document.createTextNode(` ${b.cases} cases`));
+    header.appendChild(label);
+    const rateEl = createEl('span', { className: `difficulty-rate ${statusOf(rate)}`, textContent: pct(rate) });
+    header.appendChild(rateEl);
+    card.appendChild(header);
+    const bar = createEl('div', { className: 'progress-bar' });
+    const fill = createEl('div', { className: `progress-fill ${statusOf(rate)}` });
+    fill.style.width = `${rate * 100}%`;
+    bar.appendChild(fill);
+    card.appendChild(bar);
+    return card;
+  }));
+
+  renderResultsList(run.results);
+}
+
+function buildStatCard(label, value, status, sub) {
+  const card = createEl('div', { className: 'stat-card' });
+  card.appendChild(createEl('div', { className: 'stat-label' }, label));
+  card.appendChild(createEl('div', { className: `stat-value ${status}` }, value));
+  card.appendChild(createEl('div', { className: 'stat-sub' }, sub));
+  return card;
+}
+
+function renderResultsList(results) {
+  const container = document.getElementById('overview-results');
+  container.replaceChildren(...results.map(r => {
+    const caseDef = state.caseMap[r.case];
+    const diff = caseDef ? caseDef.difficulty : '?';
+    const status = statusOf(r.passRate);
+
+    const row = createEl('div', { className: 'result-row', 'data-case': r.case });
+    row.appendChild(createEl('div', { className: `result-icon ${status}` }, statusIcon(r.passRate)));
+    const info = createEl('div');
+    info.appendChild(createEl('div', { className: 'result-name' }, r.case));
+    info.appendChild(createEl('div', { className: 'result-desc' }, caseDef ? caseDef.description : ''));
+    row.appendChild(info);
+    row.appendChild(difficultyPill(diff));
+    row.appendChild(createEl('div', { className: `result-score ${status}` }, `${r.passed}/${r.total}`));
+    row.appendChild(statusPill(status));
+    row.addEventListener('click', () => showResultDetail(r.case));
+    return row;
+  }));
+}
+
+// === Filters ===
+function setupFilters() {
+  const diffFilter = document.getElementById('filter-difficulty');
+  const statusFilter = document.getElementById('filter-status');
+  const searchFilter = document.getElementById('filter-search');
+
+  const applyFilters = () => {
+    if (!state.latest) return;
+    let results = [...state.latest.results];
+
+    const diff = diffFilter.value;
+    if (diff) {
+      results = results.filter(r => {
+        const c = state.caseMap[r.case];
+        return c && c.difficulty === diff;
+      });
+    }
+
+    const status = statusFilter.value;
+    if (status) {
+      results = results.filter(r => statusOf(r.passRate) === status);
+    }
+
+    const search = searchFilter.value.toLowerCase();
+    if (search) {
+      results = results.filter(r => {
+        const c = state.caseMap[r.case];
+        return r.case.toLowerCase().includes(search) ||
+          (c && c.description.toLowerCase().includes(search));
+      });
+    }
+
+    renderResultsList(results);
+  };
+
+  diffFilter.addEventListener('change', applyFilters);
+  statusFilter.addEventListener('change', applyFilters);
+  searchFilter.addEventListener('input', applyFilters);
+}
+
+// === Detail View ===
+function showResultDetail(caseName, runData) {
+  const run = runData || state.latest;
+  const result = run.results.find(r => r.case === caseName);
+  if (!result) return;
+
+  const caseDef = state.caseMap[caseName];
+  const status = statusOf(result.passRate);
+  const container = document.getElementById('result-detail');
+  container.replaceChildren();
+
+  // Back button
+  const backBtn = createEl('button', { className: 'detail-back' }, '\u2190 Back to overview');
+  backBtn.addEventListener('click', () => showView('overview'));
+  container.appendChild(backBtn);
+
+  // Header
+  const header = createEl('div', { className: 'detail-header' });
+  const headerLeft = createEl('div');
+  headerLeft.appendChild(createEl('h1', { className: 'detail-title' }, caseName));
+  headerLeft.appendChild(createEl('p', { style: { color: 'var(--text-gray)', marginTop: '4px' } }, caseDef ? caseDef.description : ''));
+  const meta = createEl('div', { className: 'detail-meta' });
+  if (caseDef) meta.appendChild(difficultyPill(caseDef.difficulty));
+  meta.appendChild(statusPill(status));
+  if (caseDef && caseDef.tags) caseDef.tags.forEach(t => meta.appendChild(tagPill(t)));
+  headerLeft.appendChild(meta);
+  header.appendChild(headerLeft);
+  const bigScore = createEl('div', { className: `stat-value ${status}` }, pct(result.passRate));
+  bigScore.style.fontSize = '48px';
+  header.appendChild(bigScore);
+  container.appendChild(header);
+
+  // Assertions
+  const assertSection = createEl('div', { className: 'detail-section' });
+  assertSection.appendChild(createEl('h3', {}, `Assertions (${result.passed}/${result.total})`));
+  result.scoreResults.forEach(sr => {
+    const row = createEl('div', { className: 'assertion-row' });
+    row.appendChild(createEl('div', { className: `assertion-icon ${sr.pass ? 'pass' : 'fail'}` }, sr.pass ? '\u2713' : '\u2717'));
+    const info = createEl('div');
+    info.appendChild(createEl('div', { className: 'assertion-type' }, sr.assertion.type + (sr.assertion.tool ? ` \u2192 ${sr.assertion.tool}` : '')));
+    info.appendChild(createEl('div', { className: 'assertion-reason' }, sr.reason));
+    if (sr.assertion.pattern) {
+      const pat = createEl('div', { style: { fontSize: '12px', color: 'var(--text-light)', marginTop: '2px', fontFamily: 'monospace' } });
+      pat.textContent = `pattern: ${sr.assertion.pattern}`;
+      info.appendChild(pat);
+    }
+    row.appendChild(info);
+    assertSection.appendChild(row);
+  });
+  container.appendChild(assertSection);
+
+  // Test Input
+  if (caseDef) {
+    const inputSection = createEl('div', { className: 'detail-section' });
+    inputSection.appendChild(createEl('h3', {}, 'Test Input'));
+    const inputText = caseDef.input || (caseDef.steps ? caseDef.steps.map((s, i) => `Step ${i + 1}: ${s.input}`).join('\n') : '');
+    inputSection.appendChild(createEl('div', { className: 'response-box', textContent: inputText }));
+    container.appendChild(inputSection);
+  }
+
+  // LLM Response
+  const respSection = createEl('div', { className: 'detail-section' });
+  respSection.appendChild(createEl('h3', {}, 'LLM Response'));
+  respSection.appendChild(createEl('div', { className: 'response-box', textContent: result.response || '(no response captured)' }));
+  container.appendChild(respSection);
+
+  // Vault Changes
+  const vaultSection = createEl('div', { className: 'detail-section' });
+  vaultSection.appendChild(createEl('h3', {}, 'Vault Changes'));
+  const vaultDiff = createEl('div', { className: 'vault-diff' });
+  ['created', 'modified', 'deleted'].forEach(key => {
+    const item = createEl('div', { className: `vault-diff-item ${key}` });
+    item.appendChild(createEl('span', { className: 'count' }, String(result.vaultDiff[key])));
+    item.appendChild(document.createTextNode(` ${key}`));
+    vaultDiff.appendChild(item);
+  });
+  vaultSection.appendChild(vaultDiff);
+  container.appendChild(vaultSection);
+
+  // Judge Results
+  if (result.judgeResults) {
+    const judgeSection = createEl('div', { className: 'detail-section' });
+    judgeSection.appendChild(createEl('h3', {}, 'Judge Evaluation'));
+    Object.entries(result.judgeResults).forEach(([key, jr]) => {
+      const row = createEl('div', { className: 'assertion-row' });
+      row.appendChild(createEl('div', { className: `assertion-icon ${jr.pass ? 'pass' : 'fail'}` }, jr.pass ? '\u2713' : '\u2717'));
+      const info = createEl('div');
+      info.appendChild(createEl('div', { className: 'assertion-type' }, key));
+      info.appendChild(createEl('div', { className: 'assertion-reason' }, jr.reason || ''));
+      row.appendChild(info);
+      judgeSection.appendChild(row);
+    });
+    container.appendChild(judgeSection);
+  }
+
+  // Case Definition
+  if (caseDef) {
+    const defSection = createEl('div', { className: 'detail-section' });
+    defSection.appendChild(createEl('h3', {}, 'Case Definition'));
+    const defBox = createEl('div', { className: 'response-box' });
+    defBox.style.fontFamily = "'SF Mono', 'Fira Code', monospace";
+    defBox.style.fontSize = '13px';
+    defBox.textContent = JSON.stringify(caseDef, null, 2);
+    defSection.appendChild(defBox);
+    container.appendChild(defSection);
+  }
+
+  showView('results');
+}
+
+// === History ===
+function renderHistory() {
+  const runs = state.history;
+  if (!runs.length) {
+    const el = document.getElementById('view-history');
+    el.replaceChildren(createEl('div', { className: 'empty-state' }, [createEl('h2', {}, 'No history yet')]));
+    return;
+  }
+
+  // Bar chart
+  const chartContainer = document.getElementById('history-chart');
+  chartContainer.replaceChildren();
+  chartContainer.appendChild(createEl('h3', { style: { marginBottom: '16px' } }, 'Pass Rate Over Time'));
+  const barsEl = createEl('div', { className: 'chart-bars' });
+  runs.slice().reverse().forEach(r => {
+    const h = Math.max(4, r.passRate * 150);
+    const wrapper = createEl('div', { className: 'chart-bar-wrapper', 'data-run-id': r.id });
+    wrapper.appendChild(createEl('div', { className: 'chart-value' }, pct(r.passRate)));
+    const bar = createEl('div', { className: 'chart-bar' });
+    bar.style.height = `${h}px`;
+    bar.style.background = barColor(r.passRate);
+    bar.title = `${r.id}: ${pct(r.passRate)}`;
+    wrapper.appendChild(bar);
+    wrapper.appendChild(createEl('div', { className: 'chart-label' }, shortDate(r.timestamp)));
+    wrapper.addEventListener('click', async () => {
+      const runData = await api(`run/${r.id}`);
+      showRunDetail(runData);
+    });
+    barsEl.appendChild(wrapper);
+  });
+  chartContainer.appendChild(barsEl);
+
+  // List
+  const listEl = document.getElementById('history-list');
+  listEl.replaceChildren(...runs.map(r => {
+    const row = createEl('div', { className: 'history-row', 'data-run-id': r.id });
+    const info = createEl('div');
+    info.appendChild(createEl('div', { className: 'run-label' }, r.id));
+    info.appendChild(createEl('div', { className: 'run-date' }, formatDate(r.timestamp)));
+    row.appendChild(info);
+    row.appendChild(createEl('div', {}, `${r.caseCount} cases`));
+    row.appendChild(createEl('div', { className: `result-score ${statusOf(r.passRate)}` }, `${r.totalPassed}/${r.totalAssertions}`));
+    row.appendChild(statusPill(statusOf(r.passRate)));
+    row.addEventListener('click', async () => {
+      const runData = await api(`run/${r.id}`);
+      showRunDetail(runData);
+    });
+    return row;
+  }));
+}
+
+function showRunDetail(runData) {
+  const container = document.getElementById('result-detail');
+  container.replaceChildren();
+
+  const totalPassed = runData.results.reduce((s, r) => s + r.passed, 0);
+  const totalAssertions = runData.results.reduce((s, r) => s + r.total, 0);
+  const rate = totalAssertions ? totalPassed / totalAssertions : 0;
+
+  const backBtn = createEl('button', { className: 'detail-back' }, '\u2190 Back to history');
+  backBtn.addEventListener('click', () => showView('history'));
+  container.appendChild(backBtn);
+
+  const header = createEl('div', { className: 'detail-header' });
+  const headerLeft = createEl('div');
+  headerLeft.appendChild(createEl('h1', { className: 'detail-title' }, runData.id));
+  headerLeft.appendChild(createEl('p', { style: { color: 'var(--text-gray)', marginTop: '4px' } }, formatDate(runData.timestamp)));
+  header.appendChild(headerLeft);
+  const bigScore = createEl('div', { className: `stat-value ${statusOf(rate)}` }, pct(rate));
+  bigScore.style.fontSize = '48px';
+  header.appendChild(bigScore);
+  container.appendChild(header);
+
+  const statsGrid = createEl('div', { className: 'stats-grid' });
+  statsGrid.style.gridTemplateColumns = 'repeat(3, 1fr)';
+  statsGrid.appendChild(buildStatCard('Cases', String(runData.results.length), 'neutral', ''));
+  statsGrid.appendChild(buildStatCard('Assertions', `${totalPassed}/${totalAssertions}`, statusOf(rate), ''));
+  statsGrid.appendChild(buildStatCard('Pass Rate', pct(rate), statusOf(rate), ''));
+  container.appendChild(statsGrid);
+
+  const resultsList = createEl('div', { className: 'results-list' });
+  runData.results.forEach(r => {
+    const caseDef = state.caseMap[r.case];
+    const diff = caseDef ? caseDef.difficulty : '?';
+    const status = statusOf(r.passRate);
+    const row = createEl('div', { className: 'result-row' });
+    row.appendChild(createEl('div', { className: `result-icon ${status}` }, statusIcon(r.passRate)));
+    const info = createEl('div');
+    info.appendChild(createEl('div', { className: 'result-name' }, r.case));
+    info.appendChild(createEl('div', { className: 'result-desc' }, caseDef ? caseDef.description : ''));
+    row.appendChild(info);
+    row.appendChild(difficultyPill(diff));
+    row.appendChild(createEl('div', { className: `result-score ${status}` }, `${r.passed}/${r.total}`));
+    row.appendChild(statusPill(status));
+    row.addEventListener('click', () => showResultDetail(r.case, runData));
+    resultsList.appendChild(row);
+  });
+  container.appendChild(resultsList);
+
+  showView('results');
+}
+
+// === Compare ===
+function renderCompareSelectors() {
+  const runs = state.history;
+  const selectA = document.getElementById('compare-a');
+  const selectB = document.getElementById('compare-b');
+
+  // Clear existing
+  selectA.replaceChildren();
+  selectB.replaceChildren();
+
+  if (state.latest) {
+    const totalP = state.latest.results.reduce((s, r) => s + r.passed, 0);
+    const totalA = state.latest.results.reduce((s, r) => s + r.total, 0);
+    const opt = createEl('option', { value: 'latest' }, `latest (${pct(totalA ? totalP / totalA : 0)})`);
+    selectA.appendChild(opt);
+  }
+  if (state.baseline) {
+    selectB.appendChild(createEl('option', { value: 'baseline' }, 'baseline'));
+  }
+
+  runs.forEach(r => {
+    const text = `${r.id} \u2014 ${pct(r.passRate)} (${shortDate(r.timestamp)})`;
+    selectA.appendChild(createEl('option', { value: r.id }, text));
+    selectB.appendChild(createEl('option', { value: r.id }, text));
+  });
+
+  if (runs.length > 1 && !state.baseline) selectB.selectedIndex = 1;
+
+  document.getElementById('compare-btn').addEventListener('click', doCompare);
+}
+
+async function doCompare() {
+  const aId = document.getElementById('compare-a').value;
+  const bId = document.getElementById('compare-b').value;
+
+  let runA, runB;
+  if (aId === 'latest') runA = state.latest;
+  else if (aId === 'baseline') runA = state.baseline;
+  else runA = await api(`run/${aId}`);
+
+  if (bId === 'latest') runB = state.latest;
+  else if (bId === 'baseline') runB = state.baseline;
+  else runB = await api(`run/${bId}`);
+
+  if (!runA || !runB) return;
+
+  const bMap = {};
+  runB.results.forEach(r => { bMap[r.case] = r; });
+
+  const allCases = [...new Set([...runA.results.map(r => r.case), ...runB.results.map(r => r.case)])];
+
+  const rows = allCases.map(c => {
+    const a = runA.results.find(r => r.case === c);
+    const b = bMap[c];
+    const caseDef = state.caseMap[c];
+    const rateA = a ? a.passRate : null;
+    const rateB = b ? b.passRate : null;
+    const delta = (rateA !== null && rateB !== null) ? rateA - rateB : null;
+    return { case: c, caseDef, rateA, rateB, delta };
+  }).sort((x, y) => {
+    if (x.delta !== null && y.delta !== null) return x.delta - y.delta;
+    return 0;
+  });
+
+  const container = document.getElementById('compare-results');
+  const table = createEl('table', { className: 'compare-table' });
+  const thead = createEl('thead');
+  const headerRow = createEl('tr');
+  ['Case', 'Difficulty', 'Run A', 'Run B', 'Delta'].forEach(h => {
+    headerRow.appendChild(createEl('th', {}, h));
+  });
+  thead.appendChild(headerRow);
+  table.appendChild(thead);
+
+  const tbody = createEl('tbody');
+  rows.forEach(r => {
+    const tr = createEl('tr');
+    const tdCase = createEl('td');
+    tdCase.appendChild(createEl('strong', {}, r.case));
+    tr.appendChild(tdCase);
+    const tdDiff = createEl('td');
+    tdDiff.appendChild(r.caseDef ? difficultyPill(r.caseDef.difficulty) : document.createTextNode('\u2014'));
+    tr.appendChild(tdDiff);
+    tr.appendChild(createEl('td', { className: r.rateA !== null ? statusOf(r.rateA) : '' }, r.rateA !== null ? pct(r.rateA) : '\u2014'));
+    tr.appendChild(createEl('td', { className: r.rateB !== null ? statusOf(r.rateB) : '' }, r.rateB !== null ? pct(r.rateB) : '\u2014'));
+    const tdDelta = createEl('td');
+    if (r.delta !== null) {
+      if (r.delta > 0) tdDelta.appendChild(createEl('span', { className: 'delta-up' }, `+${pct(r.delta)}`));
+      else if (r.delta < 0) tdDelta.appendChild(createEl('span', { className: 'delta-down' }, pct(r.delta)));
+      else tdDelta.appendChild(createEl('span', { className: 'delta-same' }, '='));
+    } else {
+      tdDelta.textContent = '\u2014';
+    }
+    tr.appendChild(tdDelta);
+    tbody.appendChild(tr);
+  });
+  table.appendChild(tbody);
+  container.replaceChildren(table);
+}
+
+// === Rubrics ===
+async function renderRubrics() {
+  try {
+    const rubrics = await api('rubrics');
+    const container = document.getElementById('rubrics-content');
+    if (!rubrics) {
+      container.replaceChildren(createEl('div', { className: 'empty-state' }, [createEl('h2', {}, 'No rubrics found')]));
+      return;
+    }
+
+    container.replaceChildren(...Object.entries(rubrics).map(([key, val]) => {
+      const card = createEl('div', { className: 'rubric-card' });
+      card.appendChild(createEl('h2', {}, key));
+      const prompt = createEl('div', { className: 'rubric-prompt' });
+      prompt.textContent = typeof val === 'string' ? val : JSON.stringify(val, null, 2);
+      card.appendChild(prompt);
+      return card;
+    }));
+  } catch {
+    const container = document.getElementById('rubrics-content');
+    container.replaceChildren(createEl('div', { className: 'empty-state' }, [createEl('h2', {}, 'Could not load rubrics')]));
+  }
+}
+
+// === Boot ===
+init().catch(err => {
+  console.error('Dashboard init failed:', err);
+  const main = document.querySelector('.main');
+  main.replaceChildren(
+    createEl('div', { className: 'empty-state' }, [
+      createEl('h2', {}, 'Failed to load'),
+      createEl('p', {}, err.message),
+    ])
+  );
+});

--- a/evals/dashboard/public/index.html
+++ b/evals/dashboard/public/index.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Limbo Eval Dashboard</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;500;600;700;800&family=Plus+Jakarta+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <nav class="nav">
+    <div class="nav-brand">
+      <span class="nav-logo">L</span>
+      <span class="nav-title">Limbo Eval</span>
+    </div>
+    <div class="nav-tabs">
+      <button class="nav-tab active" data-view="overview">Overview</button>
+      <button class="nav-tab" data-view="results">Results</button>
+      <button class="nav-tab" data-view="history">History</button>
+      <button class="nav-tab" data-view="compare">Compare</button>
+      <button class="nav-tab" data-view="rubrics">Rubrics</button>
+    </div>
+    <div class="nav-meta" id="nav-meta"></div>
+  </nav>
+
+  <main class="main">
+    <!-- Overview -->
+    <section id="view-overview" class="view active">
+      <div class="overview-header">
+        <h1>Latest Run</h1>
+        <p class="run-id" id="overview-run-id"></p>
+      </div>
+      <div class="stats-grid" id="overview-stats"></div>
+      <div class="difficulty-grid" id="overview-difficulty"></div>
+      <div class="section-title">Results by Case</div>
+      <div class="filters">
+        <select id="filter-difficulty">
+          <option value="">All difficulties</option>
+          <option value="easy">Easy</option>
+          <option value="medium">Medium</option>
+          <option value="hard">Hard</option>
+        </select>
+        <select id="filter-status">
+          <option value="">All statuses</option>
+          <option value="pass">Passed</option>
+          <option value="fail">Failed</option>
+          <option value="partial">Partial</option>
+        </select>
+        <input type="text" id="filter-search" placeholder="Search cases...">
+      </div>
+      <div class="results-list" id="overview-results"></div>
+    </section>
+
+    <!-- Individual Result -->
+    <section id="view-results" class="view">
+      <div id="result-detail"></div>
+    </section>
+
+    <!-- History -->
+    <section id="view-history" class="view">
+      <h1>Run History</h1>
+      <div class="history-chart" id="history-chart"></div>
+      <div class="history-list" id="history-list"></div>
+    </section>
+
+    <!-- Compare -->
+    <section id="view-compare" class="view">
+      <h1>Compare Runs</h1>
+      <div class="compare-selectors">
+        <div class="compare-col">
+          <label>Run A</label>
+          <select id="compare-a"></select>
+        </div>
+        <div class="compare-col">
+          <label>Run B</label>
+          <select id="compare-b"></select>
+        </div>
+        <button class="btn-primary" id="compare-btn">Compare</button>
+      </div>
+      <div id="compare-results"></div>
+    </section>
+
+    <!-- Rubrics -->
+    <section id="view-rubrics" class="view">
+      <h1>Judge Rubrics</h1>
+      <div id="rubrics-content"></div>
+    </section>
+  </main>
+
+  <script src="app.js"></script>
+</body>
+</html>

--- a/evals/dashboard/public/styles.css
+++ b/evals/dashboard/public/styles.css
@@ -1,0 +1,713 @@
+/* === Limbo Design System Tokens === */
+:root {
+  --orange-primary: #FF6B4A;
+  --orange-bright: #FF7A5C;
+  --coral: #FF8B7A;
+  --pink: #FF9F8E;
+  --peach: #FFB8AA;
+  --cream: #FFF5F2;
+  --card-bg: #FFFFFF;
+  --text-dark: #1A1A1A;
+  --text-gray: #555555;
+  --text-light: #888888;
+  --border-light: #E8E8E8;
+  --border-subtle: #F0F0F0;
+  --line-color: #FF6B4A33;
+  --radius-sm: 8px;
+  --radius-md: 14px;
+  --radius-lg: 20px;
+  --radius-xl: 24px;
+  --shadow-sm: 0 2px 8px rgba(0, 0, 0, 0.03);
+  --shadow-md: 0 4px 16px rgba(0, 0, 0, 0.024);
+  --shadow-lg: 0 8px 24px rgba(0, 0, 0, 0.04);
+  --shadow-glow: 0 8px 24px rgba(255, 107, 74, 0.12);
+
+  /* Semantic status colors */
+  --green: #22C55E;
+  --green-bg: #F0FDF4;
+  --green-border: #BBF7D0;
+  --red: #EF4444;
+  --red-bg: #FEF2F2;
+  --red-border: #FECACA;
+  --yellow: #F59E0B;
+  --yellow-bg: #FFFBEB;
+  --yellow-border: #FDE68A;
+}
+
+* { margin: 0; padding: 0; box-sizing: border-box; }
+
+body {
+  font-family: 'Plus Jakarta Sans', -apple-system, sans-serif;
+  background: var(--cream);
+  color: var(--text-dark);
+  min-height: 100vh;
+}
+
+h1, h2, h3, h4 {
+  font-family: 'Outfit', sans-serif;
+}
+
+/* === Nav === */
+.nav {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 12px 32px;
+  background: rgba(255, 255, 255, 0.85);
+  backdrop-filter: blur(12px);
+  border-bottom: 1px solid var(--border-light);
+  position: sticky;
+  top: 0;
+  z-index: 100;
+}
+
+.nav-brand {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-right: 16px;
+}
+
+.nav-logo {
+  width: 32px;
+  height: 32px;
+  background: linear-gradient(135deg, var(--orange-primary), var(--coral));
+  color: white;
+  border-radius: var(--radius-sm);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: 'Outfit', sans-serif;
+  font-weight: 800;
+  font-size: 18px;
+}
+
+.nav-title {
+  font-family: 'Outfit', sans-serif;
+  font-weight: 700;
+  font-size: 18px;
+  color: var(--text-dark);
+}
+
+.nav-tabs {
+  display: flex;
+  gap: 4px;
+}
+
+.nav-tab {
+  background: transparent;
+  border: none;
+  padding: 8px 16px;
+  border-radius: var(--radius-sm);
+  font-family: 'Plus Jakarta Sans', sans-serif;
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--text-gray);
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.nav-tab:hover {
+  background: var(--cream);
+  color: var(--text-dark);
+}
+
+.nav-tab.active {
+  background: var(--orange-primary);
+  color: white;
+}
+
+.nav-meta {
+  margin-left: auto;
+  font-size: 13px;
+  color: var(--text-light);
+}
+
+/* === Main === */
+.main {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 32px 24px;
+}
+
+.view { display: none; }
+.view.active { display: block; }
+
+/* === Overview === */
+.overview-header {
+  margin-bottom: 24px;
+}
+
+.overview-header h1 {
+  font-size: 32px;
+  font-weight: 700;
+}
+
+.run-id {
+  color: var(--text-light);
+  font-size: 14px;
+  margin-top: 4px;
+}
+
+/* Stats Grid */
+.stats-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 16px;
+  margin-bottom: 24px;
+}
+
+.stat-card {
+  background: var(--card-bg);
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius-lg);
+  padding: 24px;
+  box-shadow: var(--shadow-md);
+}
+
+.stat-label {
+  font-size: 13px;
+  color: var(--text-light);
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-bottom: 8px;
+}
+
+.stat-value {
+  font-family: 'Outfit', sans-serif;
+  font-size: 36px;
+  font-weight: 700;
+}
+
+.stat-value.pass { color: var(--green); }
+.stat-value.fail { color: var(--red); }
+.stat-value.partial { color: var(--yellow); }
+.stat-value.neutral { color: var(--text-dark); }
+
+.stat-sub {
+  font-size: 13px;
+  color: var(--text-light);
+  margin-top: 4px;
+}
+
+/* Difficulty Grid */
+.difficulty-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 16px;
+  margin-bottom: 32px;
+}
+
+.difficulty-card {
+  background: var(--card-bg);
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius-md);
+  padding: 20px;
+  box-shadow: var(--shadow-sm);
+}
+
+.difficulty-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 12px;
+}
+
+.difficulty-label {
+  font-family: 'Outfit', sans-serif;
+  font-weight: 600;
+  font-size: 16px;
+}
+
+.difficulty-rate {
+  font-family: 'Outfit', sans-serif;
+  font-weight: 700;
+  font-size: 24px;
+}
+
+.progress-bar {
+  height: 6px;
+  background: var(--border-subtle);
+  border-radius: 3px;
+  overflow: hidden;
+}
+
+.progress-fill {
+  height: 100%;
+  border-radius: 3px;
+  transition: width 0.6s ease;
+}
+
+.progress-fill.pass { background: var(--green); }
+.progress-fill.partial { background: var(--yellow); }
+.progress-fill.fail { background: var(--red); }
+
+/* Pill */
+.pill {
+  display: inline-block;
+  padding: 4px 10px;
+  border-radius: 100px;
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+}
+
+.pill-easy { background: var(--green-bg); color: var(--green); border: 1px solid var(--green-border); }
+.pill-medium { background: var(--yellow-bg); color: var(--yellow); border: 1px solid var(--yellow-border); }
+.pill-hard { background: var(--red-bg); color: var(--red); border: 1px solid var(--red-border); }
+.pill-pass { background: var(--green-bg); color: var(--green); border: 1px solid var(--green-border); }
+.pill-fail { background: var(--red-bg); color: var(--red); border: 1px solid var(--red-border); }
+.pill-partial { background: var(--yellow-bg); color: var(--yellow); border: 1px solid var(--yellow-border); }
+
+/* Section title */
+.section-title {
+  font-family: 'Outfit', sans-serif;
+  font-size: 20px;
+  font-weight: 600;
+  margin-bottom: 16px;
+}
+
+/* Filters */
+.filters {
+  display: flex;
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.filters select,
+.filters input {
+  padding: 8px 16px;
+  border: 1.5px solid var(--border-light);
+  border-radius: var(--radius-sm);
+  font-family: 'Plus Jakarta Sans', sans-serif;
+  font-size: 14px;
+  color: var(--text-dark);
+  background: white;
+  outline: none;
+  transition: border-color 0.2s;
+}
+
+.filters select:focus,
+.filters input:focus {
+  border-color: var(--orange-primary);
+}
+
+.filters input {
+  flex: 1;
+}
+
+/* Results List */
+.results-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.result-row {
+  display: grid;
+  grid-template-columns: 36px 1fr auto auto auto;
+  align-items: center;
+  gap: 16px;
+  padding: 16px 20px;
+  background: var(--card-bg);
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: all 0.2s;
+  box-shadow: var(--shadow-sm);
+}
+
+.result-row:hover {
+  border-color: var(--orange-primary);
+  box-shadow: var(--shadow-glow);
+  transform: translateY(-1px);
+}
+
+.result-icon {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 16px;
+  font-weight: 700;
+}
+
+.result-icon.pass { background: var(--green-bg); color: var(--green); }
+.result-icon.fail { background: var(--red-bg); color: var(--red); }
+.result-icon.partial { background: var(--yellow-bg); color: var(--yellow); }
+
+.result-name {
+  font-weight: 600;
+  font-size: 15px;
+}
+
+.result-desc {
+  font-size: 13px;
+  color: var(--text-light);
+  margin-top: 2px;
+}
+
+.result-score {
+  font-family: 'Outfit', sans-serif;
+  font-weight: 700;
+  font-size: 18px;
+}
+
+/* === Detail View === */
+.detail-back {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--text-gray);
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  margin-bottom: 20px;
+  background: none;
+  border: none;
+  font-family: 'Plus Jakarta Sans', sans-serif;
+}
+
+.detail-back:hover { color: var(--orange-primary); }
+
+.detail-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  margin-bottom: 24px;
+}
+
+.detail-title {
+  font-size: 28px;
+  font-weight: 700;
+}
+
+.detail-meta {
+  display: flex;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.detail-section {
+  background: var(--card-bg);
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius-lg);
+  padding: 24px;
+  margin-bottom: 16px;
+  box-shadow: var(--shadow-sm);
+}
+
+.detail-section h3 {
+  font-size: 16px;
+  font-weight: 600;
+  margin-bottom: 16px;
+  color: var(--text-dark);
+}
+
+.assertion-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 12px 0;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.assertion-row:last-child { border-bottom: none; }
+
+.assertion-icon {
+  flex-shrink: 0;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.assertion-icon.pass { background: var(--green-bg); color: var(--green); }
+.assertion-icon.fail { background: var(--red-bg); color: var(--red); }
+
+.assertion-type {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-light);
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+}
+
+.assertion-reason {
+  font-size: 14px;
+  color: var(--text-gray);
+  margin-top: 2px;
+}
+
+.response-box {
+  background: var(--cream);
+  border-radius: var(--radius-sm);
+  padding: 16px;
+  font-size: 14px;
+  color: var(--text-gray);
+  line-height: 1.6;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.vault-diff {
+  display: flex;
+  gap: 16px;
+}
+
+.vault-diff-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 14px;
+}
+
+.vault-diff-item .count {
+  font-family: 'Outfit', sans-serif;
+  font-weight: 700;
+}
+
+.vault-diff-item.created .count { color: var(--green); }
+.vault-diff-item.modified .count { color: var(--yellow); }
+.vault-diff-item.deleted .count { color: var(--red); }
+
+/* === History === */
+.history-chart {
+  background: var(--card-bg);
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius-lg);
+  padding: 24px;
+  margin-bottom: 24px;
+  box-shadow: var(--shadow-md);
+  min-height: 200px;
+}
+
+.chart-bars {
+  display: flex;
+  align-items: flex-end;
+  gap: 8px;
+  height: 160px;
+  padding-top: 8px;
+}
+
+.chart-bar-wrapper {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  height: 100%;
+  justify-content: flex-end;
+}
+
+.chart-bar {
+  width: 100%;
+  max-width: 48px;
+  border-radius: 4px 4px 0 0;
+  transition: all 0.3s;
+  cursor: pointer;
+  min-height: 4px;
+}
+
+.chart-bar:hover { opacity: 0.8; }
+
+.chart-label {
+  font-size: 10px;
+  color: var(--text-light);
+  text-align: center;
+  white-space: nowrap;
+}
+
+.chart-value {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-dark);
+}
+
+.history-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.history-row {
+  display: grid;
+  grid-template-columns: 1fr auto auto auto;
+  align-items: center;
+  gap: 16px;
+  padding: 16px 20px;
+  background: var(--card-bg);
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-sm);
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.history-row:hover {
+  border-color: var(--orange-primary);
+  box-shadow: var(--shadow-glow);
+}
+
+.history-row .run-label {
+  font-weight: 600;
+  font-size: 15px;
+}
+
+.history-row .run-date {
+  font-size: 13px;
+  color: var(--text-light);
+  margin-top: 2px;
+}
+
+/* === Compare === */
+.compare-selectors {
+  display: flex;
+  gap: 16px;
+  align-items: flex-end;
+  margin-bottom: 24px;
+}
+
+.compare-col {
+  flex: 1;
+}
+
+.compare-col label {
+  display: block;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-light);
+  margin-bottom: 6px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.compare-col select {
+  width: 100%;
+  padding: 10px 16px;
+  border: 1.5px solid var(--border-light);
+  border-radius: var(--radius-sm);
+  font-family: 'Plus Jakarta Sans', sans-serif;
+  font-size: 14px;
+  background: white;
+  color: var(--text-dark);
+}
+
+.btn-primary {
+  padding: 10px 24px;
+  background: linear-gradient(135deg, var(--orange-primary), var(--coral));
+  color: white;
+  border: none;
+  border-radius: var(--radius-sm);
+  font-family: 'Plus Jakarta Sans', sans-serif;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s;
+  white-space: nowrap;
+}
+
+.btn-primary:hover {
+  box-shadow: var(--shadow-glow);
+  transform: scale(1.02);
+}
+
+.btn-primary:active {
+  transform: scale(0.98);
+}
+
+.compare-table {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  background: var(--card-bg);
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  box-shadow: var(--shadow-md);
+}
+
+.compare-table th {
+  background: var(--cream);
+  padding: 12px 16px;
+  text-align: left;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-light);
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+  border-bottom: 1px solid var(--border-light);
+}
+
+.compare-table td {
+  padding: 12px 16px;
+  font-size: 14px;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.compare-table tr:last-child td { border-bottom: none; }
+
+.delta-up { color: var(--green); font-weight: 600; }
+.delta-down { color: var(--red); font-weight: 600; }
+.delta-same { color: var(--text-light); }
+
+/* === Rubrics === */
+.rubric-card {
+  background: var(--card-bg);
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius-lg);
+  padding: 24px;
+  margin-bottom: 16px;
+  box-shadow: var(--shadow-sm);
+}
+
+.rubric-card h2 {
+  font-size: 20px;
+  font-weight: 700;
+  margin-bottom: 12px;
+}
+
+.rubric-prompt {
+  background: var(--cream);
+  border-radius: var(--radius-sm);
+  padding: 16px;
+  font-size: 13px;
+  color: var(--text-gray);
+  line-height: 1.6;
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-family: 'SF Mono', 'Fira Code', monospace;
+}
+
+/* === Empty state === */
+.empty-state {
+  text-align: center;
+  padding: 64px 24px;
+  color: var(--text-light);
+}
+
+.empty-state h2 {
+  font-size: 24px;
+  font-weight: 600;
+  color: var(--text-gray);
+  margin-bottom: 8px;
+}
+
+/* === Responsive === */
+@media (max-width: 768px) {
+  .stats-grid { grid-template-columns: repeat(2, 1fr); }
+  .difficulty-grid { grid-template-columns: 1fr; }
+  .nav { padding: 12px 16px; flex-wrap: wrap; }
+  .nav-tabs { order: 3; width: 100%; overflow-x: auto; }
+  .result-row { grid-template-columns: 36px 1fr auto; }
+  .result-desc, .result-row > :nth-child(4) { display: none; }
+  .compare-selectors { flex-direction: column; }
+}

--- a/evals/dashboard/server.js
+++ b/evals/dashboard/server.js
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+const PORT = process.env.PORT || 3737;
+const EVALS_DIR = path.resolve(__dirname, '..');
+
+const MIME = {
+  '.html': 'text/html',
+  '.css': 'text/css',
+  '.js': 'application/javascript',
+  '.json': 'application/json',
+  '.svg': 'image/svg+xml',
+};
+
+function jsonRes(res, data, status = 200) {
+  res.writeHead(status, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify(data));
+}
+
+function readJSON(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+// API routes
+const api = {
+  '/api/cases'() {
+    const casesDir = path.join(EVALS_DIR, 'cases');
+    const files = fs.readdirSync(casesDir).filter(f => f.endsWith('.json'));
+    return files.map(f => readJSON(path.join(casesDir, f)));
+  },
+
+  '/api/latest'() {
+    const p = path.join(EVALS_DIR, 'results', 'latest.json');
+    return fs.existsSync(p) ? readJSON(p) : null;
+  },
+
+  '/api/baseline'() {
+    const p = path.join(EVALS_DIR, 'results', 'baseline.json');
+    return fs.existsSync(p) ? readJSON(p) : null;
+  },
+
+  '/api/history'() {
+    const dir = path.join(EVALS_DIR, 'results', 'history');
+    if (!fs.existsSync(dir)) return [];
+    const files = fs.readdirSync(dir)
+      .filter(f => f.endsWith('.json'))
+      .sort()
+      .reverse();
+    return files.map(f => {
+      const run = readJSON(path.join(dir, f));
+      // Return summary for list view (don't send all scoreResults)
+      const totalPassed = run.results.reduce((s, r) => s + r.passed, 0);
+      const totalAssertions = run.results.reduce((s, r) => s + r.total, 0);
+      return {
+        id: run.id,
+        timestamp: run.timestamp,
+        caseCount: run.results.length,
+        totalPassed,
+        totalAssertions,
+        passRate: totalAssertions ? totalPassed / totalAssertions : 0,
+      };
+    });
+  },
+
+  '/api/run/:id'(params) {
+    const dir = path.join(EVALS_DIR, 'results', 'history');
+    const file = `${params.id}.json`;
+    const p = path.join(dir, file);
+    if (!fs.existsSync(p)) return null;
+    return readJSON(p);
+  },
+
+  '/api/rubrics'() {
+    const p = path.join(EVALS_DIR, 'judge', 'rubrics.json');
+    return fs.existsSync(p) ? readJSON(p) : null;
+  },
+};
+
+const server = http.createServer((req, res) => {
+  const url = new URL(req.url, `http://localhost:${PORT}`);
+  const pathname = url.pathname === '/' ? '/index.html' : url.pathname;
+
+  // API routing
+  if (pathname.startsWith('/api/')) {
+    // Check parameterized routes
+    const runMatch = pathname.match(/^\/api\/run\/(.+)$/);
+    if (runMatch) {
+      const data = api['/api/run/:id']({ id: runMatch[1] });
+      if (!data) return jsonRes(res, { error: 'Not found' }, 404);
+      return jsonRes(res, data);
+    }
+
+    const handler = api[pathname];
+    if (handler) {
+      try {
+        return jsonRes(res, handler());
+      } catch (e) {
+        return jsonRes(res, { error: e.message }, 500);
+      }
+    }
+    return jsonRes(res, { error: 'Not found' }, 404);
+  }
+
+  // Static files from dashboard/public
+  const filePath = path.join(__dirname, 'public', pathname);
+  const ext = path.extname(filePath);
+
+  if (!fs.existsSync(filePath)) {
+    res.writeHead(404);
+    return res.end('Not found');
+  }
+
+  res.writeHead(200, { 'Content-Type': MIME[ext] || 'text/plain' });
+  fs.createReadStream(filePath).pipe(res);
+});
+
+server.listen(PORT, () => {
+  console.log(`\n  🔥 Limbo Eval Dashboard → http://localhost:${PORT}\n`);
+});


### PR DESCRIPTION
## Summary
- Adds a lightweight Node.js dashboard (`evals/dashboard/`) to visualize eval results locally
- Overview with pass rates by difficulty, filterable results list, individual case detail with assertions/response/vault changes
- Historical run chart + comparison view (latest vs baseline or any two runs)
- 100% data-driven: reads JSON from `evals/results/` and `evals/cases/` — new test cases appear automatically
- Uses Limbo brand design system (Outfit + Plus Jakarta Sans, orange/cream palette)

## Usage
```bash
node evals/dashboard/server.js   # → http://localhost:3737
```

## Test plan
- [ ] Start server, verify overview loads with latest run data
- [ ] Click individual case, verify assertions/response/vault diff render correctly
- [ ] Check history view shows bar chart and run list
- [ ] Compare latest vs baseline, verify delta table
- [ ] Filter by difficulty and status, verify results update
- [ ] Add a new eval case, run evals, verify it appears in dashboard without code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)