### PR TITLE
chore: add docker log rotation to all compose files

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -12,6 +12,11 @@ services:
     volumes:
       - limbo-test-data:/data
       - limbo-test-state:/home/limbo/.zeroclaw
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
     tmpfs:
       - /tmp:size=100M
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,11 @@ services:
       - .env
     environment:
       NODE_OPTIONS: "${LIMBO_NODE_OPTIONS:---max-old-space-size=256}"
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
     healthcheck:
       test:
         [

--- a/evals/docker-compose.eval.yml
+++ b/evals/docker-compose.eval.yml
@@ -21,6 +21,11 @@ services:
     environment:
       LIMBO_EVAL: "true"
       LIMBO_PORT: "18790"
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
     tmpfs:
       - /tmp:size=100M
     healthcheck:


### PR DESCRIPTION
## Summary
- Add `json-file` log driver with rotation (3 × 10MB max) to all Docker Compose services
- Prevents unbounded log growth on long-running containers
- Applied to `docker-compose.yml`, `docker-compose.test.yml`, and `evals/docker-compose.eval.yml`

## Test plan
- [ ] `docker compose config` validates on each compose file
- [ ] `limbo logs` still works after restart with rotation enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)