### PR TITLE
Default OpenAI subscription reasoning effort to medium

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,6 +28,10 @@
 # Codex subscription example: gpt-5.4
 # MODEL_NAME=claude-opus-4-6
 
+# Default reasoning effort. Limbo now defaults this to medium instead of
+# inheriting ZeroClaw's more aggressive Codex default.
+# RUNTIME_REASONING_EFFORT=medium
+
 # ── Telegram Integration (optional) ──────────────────────────────────────────
 
 # Enable Telegram bot integration

--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ Managed by `limbo start`, stored in `~/.limbo/.env`.
 | `AUTH_MODE` | `api-key` | `api-key` or `subscription` |
 | `MODEL_PROVIDER` | `anthropic` | `anthropic`, `openai`, `openai-codex`, or `openrouter` |
 | `MODEL_NAME` | `claude-sonnet-4-6` | Model to use |
+| `RUNTIME_REASONING_EFFORT` | `medium` | ZeroClaw `runtime.reasoning_effort` override |
 | `TELEGRAM_ENABLED` | `false` | Enable Telegram integration |
 | `VOICE_ENABLED` | `false` | Enable Groq voice transcription |
 | `WEB_SEARCH_ENABLED` | `false` | Enable Brave web search |

--- a/config.toml.template
+++ b/config.toml.template
@@ -5,6 +5,9 @@
 default_provider = "${MODEL_PROVIDER}"
 default_model = "${MODEL_NAME}"
 
+[runtime]
+reasoning_effort = "${RUNTIME_REASONING_EFFORT}"
+
 [gateway]
 host = "127.0.0.1"
 port = ${LIMBO_PORT}

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -40,6 +40,7 @@ LLM_API_KEY="${_secret_llm:-${LLM_API_KEY:-}}"
 # ── Defaults ─────────────────────────────────────────────────────────────────
 MODEL_PROVIDER="${MODEL_PROVIDER:-anthropic}"
 MODEL_NAME="${MODEL_NAME:-claude-opus-4-6}"
+RUNTIME_REASONING_EFFORT="${RUNTIME_REASONING_EFFORT:-medium}"
 TELEGRAM_ENABLED="${TELEGRAM_ENABLED:-false}"
 TELEGRAM_BOT_TOKEN="${_secret_telegram:-${TELEGRAM_BOT_TOKEN:-}}"
 VOICE_ENABLED="${VOICE_ENABLED:-false}"
@@ -214,8 +215,8 @@ else
   fi
 
   log "INFO  Generating ZeroClaw config from template"
-  export MODEL_PROVIDER MODEL_NAME LIMBO_PORT
-  envsubst '$MODEL_PROVIDER $MODEL_NAME $LIMBO_PORT' \
+  export MODEL_PROVIDER MODEL_NAME LIMBO_PORT RUNTIME_REASONING_EFFORT
+  envsubst '$MODEL_PROVIDER $MODEL_NAME $LIMBO_PORT $RUNTIME_REASONING_EFFORT' \
     < /app/config.toml.template > "$ZEROCLAW_CONFIG_PATH"
 
   # Telegram: channel is enabled by section presence, not a boolean flag.

--- a/test/zeroclaw-migration.test.js
+++ b/test/zeroclaw-migration.test.js
@@ -74,7 +74,7 @@ test('config.toml.template does NOT contain unsupported sections', () => {
 
 test('config.toml.template uses envsubst variables', () => {
   const toml = read('config.toml.template');
-  const vars = ['${MODEL_PROVIDER}', '${MODEL_NAME}', '${LIMBO_PORT}'];
+  const vars = ['${MODEL_PROVIDER}', '${MODEL_NAME}', '${LIMBO_PORT}', '${RUNTIME_REASONING_EFFORT}'];
   for (const v of vars) {
     assert.ok(toml.includes(v), `Missing envsubst variable: ${v}`);
   }


### PR DESCRIPTION
## Summary
- set Limbo's default ZeroClaw reasoning effort to medium
- stop inheriting the upstream openai-codex xhigh fallback for subscription users
- document the new env override and keep template tests aligned

## Validation
- npm test -- --test-name-pattern='config.toml.template uses envsubst variables|config.toml.template uses require_pairing for gateway auth|config.toml.template registers MCP server via \\[\\[mcp.servers\\]\\]'
