### PR TITLE
fix: USER.md template envsubst defaults

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -192,6 +192,10 @@ done
 
 # USER.md: generate from template via envsubst on first run
 if [ ! -f "$ZC_WORKSPACE/USER.md" ]; then
+  USER_NAME="${USER_NAME:-User}"
+  USER_TIMEZONE="${USER_TIMEZONE:-}"
+  USER_LANGUAGE="${USER_LANGUAGE:-English}"
+  USER_CONTEXT="${USER_CONTEXT:-No additional context provided.}"
   export USER_NAME USER_TIMEZONE USER_LANGUAGE USER_CONTEXT
   envsubst '$USER_NAME $USER_TIMEZONE $USER_LANGUAGE $USER_CONTEXT' \
     < /app/workspace/templates/USER.md.template > "$ZC_WORKSPACE/USER.md"

--- a/workspace/templates/USER.md.template
+++ b/workspace/templates/USER.md.template
@@ -4,16 +4,16 @@ This file was generated at first run from environment variables. It personalizes
 
 ## Identity
 
-- **Name:** ${USER_NAME:-User}
-- **Timezone:** ${USER_TIMEZONE:-UTC}
-- **Language:** ${USER_LANGUAGE:-English}
+- **Name:** $USER_NAME
+- **Timezone:** $USER_TIMEZONE
+- **Language:** $USER_LANGUAGE
 
 ## Communication Preferences
 
-Respond in **${USER_LANGUAGE:-English}**. Keep responses concise by default unless the user asks for more detail.
+Respond in **$USER_LANGUAGE**. Keep responses concise by default unless the user asks for more detail.
 
-Address the user as **${USER_NAME:-User}** when it feels natural, but don't overdo it.
+Address the user as **$USER_NAME** when it feels natural, but don't overdo it.
 
 ## Additional Context
 
-${USER_CONTEXT:-No additional context provided.}
+$USER_CONTEXT


### PR DESCRIPTION
## Summary
- Fix USER.md.template to use plain `$VAR` instead of `${VAR:-default}` (envsubst doesn't support bash defaults)
- Set explicit defaults in entrypoint.sh before envsubst runs

## Test plan
- [ ] Verify USER.md renders correctly on fresh container start
- [ ] Verify empty timezone field when USER_TIMEZONE is unset

🤖 Generated with [Claude Code](https://claude.com/claude-code)