### PR TITLE
test(evals): add workspace_read/write eval cases

### DIFF
--- a/evals/cases/workspace-read-identity.json
+++ b/evals/cases/workspace-read-identity.json
@@ -1,0 +1,14 @@
+{
+  "name": "workspace-read-identity",
+  "description": "Agent reads its own identity file when asked what it is",
+  "input": "Qué sos? Contame sobre vos",
+  "assertions": [
+    { "type": "tool_called", "tool": "workspace_read" },
+    { "type": "param_match", "tool": "workspace_read", "key": "filename", "pattern": "IDENTITY\\.md" },
+    { "type": "response_matches", "pattern": "(?i)(limbo|vault|asistente|memoria|personal)" }
+  ],
+  "runs": 1,
+  "pass_threshold": 0.66,
+  "tags": ["workspace", "workspace_read"],
+  "difficulty": "easy"
+}

--- a/evals/cases/workspace-write-timezone.json
+++ b/evals/cases/workspace-write-timezone.json
@@ -1,0 +1,17 @@
+{
+  "name": "workspace-write-timezone",
+  "description": "Agent persists user timezone to USER.md via workspace_write",
+  "input": "Mi timezone es America/Argentina/Buenos_Aires",
+  "assertions": [
+    { "type": "tool_called", "tool": "workspace_read" },
+    { "type": "param_match", "tool": "workspace_read", "key": "filename", "pattern": "USER\\.md" },
+    { "type": "tool_called", "tool": "workspace_write" },
+    { "type": "param_match", "tool": "workspace_write", "key": "filename", "pattern": "USER\\.md" },
+    { "type": "param_match", "tool": "workspace_write", "key": "content", "pattern": "(?i)america/argentina/buenos_aires" },
+    { "type": "user_profile_matches", "pattern": "(?i)america/argentina/buenos_aires" }
+  ],
+  "runs": 1,
+  "pass_threshold": 0.8,
+  "tags": ["workspace", "workspace_write", "user_profile"],
+  "difficulty": "easy"
+}

--- a/evals/cases/workspace-write-username.json
+++ b/evals/cases/workspace-write-username.json
@@ -1,0 +1,18 @@
+{
+  "name": "workspace-write-username",
+  "description": "Agent persists user name to USER.md via workspace_write",
+  "input": "Che, me llamo Santiago. Guardalo así te acordás",
+  "assertions": [
+    { "type": "tool_called", "tool": "workspace_read" },
+    { "type": "param_match", "tool": "workspace_read", "key": "filename", "pattern": "USER\\.md" },
+    { "type": "tool_called", "tool": "workspace_write" },
+    { "type": "param_match", "tool": "workspace_write", "key": "filename", "pattern": "USER\\.md" },
+    { "type": "param_match", "tool": "workspace_write", "key": "content", "pattern": "(?i)santiago" },
+    { "type": "user_profile_matches", "pattern": "(?i)santiago" },
+    { "type": "response_matches", "pattern": "(?i)(santiago|guardé|guardado|actualicé|listo)" }
+  ],
+  "runs": 1,
+  "pass_threshold": 0.8,
+  "tags": ["workspace", "workspace_write", "user_profile"],
+  "difficulty": "easy"
+}


### PR DESCRIPTION
## Summary
- 3 new eval cases covering the workspace tools introduced in #201
- `workspace-read-identity`: agent reads IDENTITY.md when asked about itself
- `workspace-write-timezone`: agent persists timezone to USER.md (read-before-write pattern)
- `workspace-write-username`: agent persists user name to USER.md (read-before-write pattern)

## Test plan
- [ ] Run `node evals/cli.js run` with workspace tools deployed and verify cases pass
- [ ] Verify no regressions on existing eval baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)