### PR TITLE
chore: bump ZeroClaw v0.6.3 → v0.6.5-codex-parity

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-ARG ZEROCLAW_IMAGE=ghcr.io/tomasward1/zeroclaw:v0.6.3-custom
+ARG ZEROCLAW_IMAGE=ghcr.io/tomasward1/zeroclaw:v0.6.5-codex-parity-custom
 # ──────────────────────────────────────────────
 # Stage 1: deps — install MCP server dependencies
 # ──────────────────────────────────────────────
@@ -21,8 +21,8 @@ RUN cd mcp-server \
 
 # ──────────────────────────────────────────────
 # Stage 2: ZeroClaw binary
-# Custom build: v0.6.3 + rag-pdf feature enabled.
-# Build with: ./scripts/build-zeroclaw.sh v0.6.3
+# Custom build: v0.6.5 + rag-pdf + codex-parity patches (native tools, previous_response_id, WS-first).
+# Built from TomasWard1/zeroclaw fork, branch codex/codex-openai-parity-fast.
 # Override with: --build-arg ZEROCLAW_IMAGE=zeroclaw:codex-openai-parity-fast-local
 # ──────────────────────────────────────────────
 FROM ${ZEROCLAW_IMAGE} AS zeroclaw


### PR DESCRIPTION
## Summary
- Bump ZeroClaw from `v0.6.3-custom` to `v0.6.5-codex-parity-custom`
- Built from [TomasWard1/zeroclaw](https://github.com/TomasWard1/zeroclaw/tree/codex/codex-openai-parity-fast) fork with OpenAI Codex parity patches

### What's in the new image
- Native tool calling for `openai-codex` provider (was prompt-based)
- `previous_response_id` for incremental session continuity
- WebSocket-first transport with automatic HTTP/SSE fallback
- Bookworm glibc builder for node:22-slim runtime compatibility
- Default reasoning effort lowered from `xhigh` to `low` for codex

## Test plan
- [ ] `docker build -t limbo:test .` succeeds
- [ ] Container starts and responds to messages with Anthropic provider
- [ ] Container starts and responds with OpenAI Codex provider (if available)

🤖 Generated with [Claude Code](https://claude.com/claude-code)