### PR TITLE
fix: guardrails against large inline content corrupting context

### DIFF
--- a/workspace/system/AGENTS.md
+++ b/workspace/system/AGENTS.md
@@ -56,3 +56,9 @@ Do NOT store facts in internal memory. If the user shares a person's name, a lin
 - After creating, report the **exact scheduled time** back to the user.
 
 **Timezone is required for time-based reminders.** If USER.md has no timezone set (empty or missing) and the reminder depends on local time (e.g. "at 9am"), you MUST ask the user for their timezone first. When they answer, update USER.md with `workspace_write` and then create the reminder in the same turn. Do not assume UTC.
+
+---
+
+## Response Size
+
+Keep responses concise. Never embed binary data, base64 strings, or large text blocks (>1000 chars) directly in messages. Reference files by path instead. Large inline content destabilizes the conversation context window and can cause irrecoverable API errors.

--- a/workspace/system/TOOLS.md
+++ b/workspace/system/TOOLS.md
@@ -4,6 +4,8 @@ You have 8 tools via MCP. ZeroClaw invokes these natively — call them by name.
 
 **⚠️ ALL user information goes to the vault via vault tools. Always.**
 
+**⚠️ NEVER include large binary content (base64, raw file bytes) in your responses.** When referencing files, always use file paths — never inline content. Large inline content can corrupt the conversation context and cause irrecoverable errors.
+
 If `USER.md` has no timezone and a reminder request depends on local time, stop and ask for the timezone first. Do not default to UTC. Once the user tells you the timezone, use it for the reminder and treat it as durable profile information.
 If the user answers a missing reminder detail in the next turn, finish the reminder immediately in that turn. Do not only acknowledge the new detail.
 


### PR DESCRIPTION
## Summary
- Add rule in TOOLS.md: never include base64/binary content inline in responses
- Add Response Size section in AGENTS.md: keep responses concise, reference files by path
- Limbo-side mitigation for ZeroClaw context compressor stripping tool_result blocks

## Context
After large payloads (e.g. base64 PDFs) enter conversation context, ZeroClaw's compressor can remove tool_result blocks while keeping tool_use blocks, causing API 400 errors. Core fix needs to happen upstream in ZeroClaw.

Closes #215

🤖 Generated with [Claude Code](https://claude.com/claude-code)