### PR TITLE
fix: vault empty regression after /new command

### DIFF
--- a/evals/cases/search-after-new-command.json
+++ b/evals/cases/search-after-new-command.json
@@ -1,0 +1,28 @@
+{
+  "name": "search-after-new-command",
+  "description": "After /new clears conversation, agent must still search vault for answers",
+  "steps": [
+    {
+      "input": "Soy alergico a algo?",
+      "assertions": [
+        { "type": "tool_called", "tool": "vault_search" },
+        { "type": "response_matches", "pattern": "(?i)(mani|peanut|alerg)" }
+      ]
+    },
+    {
+      "type": "command",
+      "content": "/new"
+    },
+    {
+      "input": "Soy alergico a algo?",
+      "assertions": [
+        { "type": "tool_called", "tool": "vault_search" },
+        { "type": "response_matches", "pattern": "(?i)(mani|peanut|alerg)" }
+      ]
+    }
+  ],
+  "runs": 1,
+  "pass_threshold": 1.0,
+  "tags": ["multi-step", "vault_search", "regression", "new-command"],
+  "difficulty": "easy"
+}

--- a/evals/cli.js
+++ b/evals/cli.js
@@ -599,6 +599,20 @@ async function cmdRun(args) {
           const step = steps[s];
           const stepLabel = steps.length > 1 ? ` [step ${s + 1}/${steps.length}]` : '';
 
+          if (step.type === 'command') {
+            // Simulate ZeroClaw commands (e.g. /new) without sending a message
+            console.log(`  Command${stepLabel}: "${step.content}"`);
+            if (step.content === '/new') {
+              // /new clears conversation history but NOT the vault
+              spawnSync('docker', ['exec', CONTAINER, 'rm', '-f', sessionStateFile], { timeout: 5000 });
+              transcriptTurns.length = 0;
+              console.log('  Session state cleared (simulated /new)');
+            } else {
+              console.log(`  ⚠ Unknown command "${step.content}" — skipped`);
+            }
+            continue;
+          }
+
           if (step.type === 'telegram_manual') {
             // Snapshot before (both .md and all files)
             const before = snapshot(VAULT_SEED);

--- a/workspace/system/AGENTS.md
+++ b/workspace/system/AGENTS.md
@@ -17,6 +17,8 @@ Before creating ANY note, call `vault_search`. If a matching note exists, update
 
 Before answering any recall question ("what do you know about X?"), call `vault_search` first. Never rely on your context window alone. The vault is your source of truth.
 
+**Critical:** If your conversation history is empty (e.g. after `/new`), that does NOT mean the vault is empty. The vault persists independently of conversation history. NEVER say "the vault is empty" or "I don't have information" without running `vault_search` first. An empty conversation is not an empty vault.
+
 ## 4. Atomic notes
 
 Each note captures one idea or fact. If a user shares multiple distinct things in one message, write multiple notes. But NEVER write two notes about the same thing.


### PR DESCRIPTION
## Summary
- Agent claimed vault was empty after `/new` without searching — now AGENTS.md explicitly states empty conversation ≠ empty vault
- Eval runner gains `command` step type to simulate `/new` (deletes session state file + clears transcript)
- New eval case `search-after-new-command`: query → /new → same query, asserts `vault_search` is called both times

## Test plan
- [x] Eval case passes 4/4 (100%) on `anthropic__claude-opus-4-6__medium` profile
- [x] Unit tests pass (134/135 — pre-existing `better-sqlite3` failure unrelated)
- [ ] Full eval suite run to confirm no regressions

Closes #204

🤖 Generated with [Claude Code](https://claude.com/claude-code)