### PR TITLE
feat(tools): reduce native tool surface to profile:minimal

### DIFF
--- a/openclaw.json.template
+++ b/openclaw.json.template
@@ -31,7 +31,9 @@
   },
 
   "tools": {
-    "profile": "full",
+    "profile": "minimal",
+    "allow": ["session_status"],
+    "deny": ["gateway", "cron"],
     "exec": {
       "timeoutSec": 1800
     }

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   },
   "scripts": {
     "start": "node cli.js start",
-    "test": "node --test test/cli-filter.test.js test/cli-auth.test.js test/cli-compose.test.js test/openclaw-migration.test.js test/setup-server.test.js test/cli-wizard-parity.test.js test/fts.test.js test/sanitize-control-chars.test.js test/mcp-tools.test.js test/entrypoint.test.js test/update-system.test.js test/session-store.test.js test/control-router.test.js test/control-server.test.js test/wizard-spawner.test.js test/control-client.test.js test/supervisor.test.js test/public-server.test.js test/google-calendar-cli.test.js test/switch-brain-cli.test.js test/cloud-cmd.test.js test/cloud-oauth.test.js test/cron.test.js",
+    "test": "node --test test/cli-filter.test.js test/cli-auth.test.js test/cli-compose.test.js test/openclaw-migration.test.js test/tool-surface.test.js test/setup-server.test.js test/cli-wizard-parity.test.js test/fts.test.js test/sanitize-control-chars.test.js test/mcp-tools.test.js test/entrypoint.test.js test/update-system.test.js test/session-store.test.js test/control-router.test.js test/control-server.test.js test/wizard-spawner.test.js test/control-client.test.js test/supervisor.test.js test/public-server.test.js test/google-calendar-cli.test.js test/switch-brain-cli.test.js test/cloud-cmd.test.js test/cloud-oauth.test.js test/cron.test.js",
     "postinstall": "[ -d mcp-server ] && cd mcp-server && npm install --ignore-scripts && cd node_modules/better-sqlite3 && npx node-gyp rebuild --release 2>/dev/null || true",
     "prepare": "if [ -n \"$CI\" ] || ! command -v husky >/dev/null 2>&1; then exit 0; fi; husky"
   },

--- a/scripts/regen-openclaw-config.sh
+++ b/scripts/regen-openclaw-config.sh
@@ -131,6 +131,12 @@ if [ "$VOICE_ENABLED" = "true" ] && [ -n "$GROQ_API_KEY" ]; then
 fi
 
 # Web search (Brave)
+#
+# Two parts: (1) provider config under tools.web.search, (2) push web_search
+# and web_fetch into tools.allow. Step (2) is required because the base
+# profile is 'minimal' — without an explicit allow entry the tools stay
+# hidden even with a provider key present. web_fetch rides along so the
+# agent can both search and fetch individual pages.
 if [ "$WEB_SEARCH_ENABLED" = "true" ] && [ -n "$BRAVE_API_KEY" ]; then
   export BRAVE_API_KEY
   node -e "
@@ -143,6 +149,10 @@ if [ "$WEB_SEARCH_ENABLED" = "true" ] && [ -n "$BRAVE_API_KEY" ]; then
       provider: 'brave',
       maxResults: 5
     };
+    cfg.tools.allow = Array.isArray(cfg.tools.allow) ? cfg.tools.allow : [];
+    for (const t of ['web_search', 'web_fetch']) {
+      if (!cfg.tools.allow.includes(t)) cfg.tools.allow.push(t);
+    }
     fs.writeFileSync(process.argv[1], JSON.stringify(cfg, null, 2));
   " "$TMP_CONFIG"
 fi

--- a/test/entrypoint.test.js
+++ b/test/entrypoint.test.js
@@ -797,8 +797,11 @@ describe('Full config pipeline integration', () => {
     // Cron
     assert.equal(final.cron.enabled, true);
 
-    // Tools
-    assert.equal(final.tools.profile, 'full');
+    // Tools — minimal profile + explicit session_status allow; gateway + native cron denied
+    assert.equal(final.tools.profile, 'minimal');
+    assert.ok(final.tools.allow.includes('session_status'));
+    assert.ok(final.tools.deny.includes('gateway'));
+    assert.ok(final.tools.deny.includes('cron'));
   });
 });
 

--- a/test/openclaw-migration.test.js
+++ b/test/openclaw-migration.test.js
@@ -77,12 +77,25 @@ test('openclaw.json.template registers limbo-vault MCP server', () => {
   assert.ok(json.includes('OPENCLAW_STATE_DIR'));
 });
 
-// Regression: manual allowlist had invalid tool names (cron, sessions)
-test('openclaw.json.template uses tool profile instead of manual allowlist', () => {
+// Regression: the old manual allowlist listed 'cron'/'sessions' as tool names,
+// which OpenClaw did not recognize. The template now uses tools.profile as the
+// base and only session_status in tools.allow. (cron *may* appear in
+// tools.deny — that's the tool-surface reduction work, not a regression.)
+test('openclaw.json.template uses tool profile instead of invalid allowlist names', () => {
   const json = read('openclaw.json.template');
   assert.ok(json.includes('"profile"'), 'Should use tools.profile');
-  assert.ok(!json.includes('"cron"') || !json.includes('"allow"'),
-    'Should not have manual allowlist with invalid tool names');
+  const cfg = JSON.parse(
+    json
+      .replace(/\$\{LIMBO_PORT\}/g, '18789')
+      .replace(/\$\{MODEL_PROVIDER\}/g, 'anthropic')
+      .replace(/\$\{MODEL_NAME\}/g, 'claude-sonnet-4-6')
+      .replace(/\$\{RUNTIME_REASONING_EFFORT\}/g, 'medium')
+      .replace(/\$\{OPENCLAW_STATE_DIR\}/g, '/home/limbo/.openclaw')
+  );
+  const allow = cfg.tools.allow || [];
+  for (const invalid of ['cron', 'sessions']) {
+    assert.ok(!allow.includes(invalid), `${invalid} is not a valid native tool name for tools.allow`);
+  }
 });
 
 test('openclaw.json.template has sandbox off', () => {

--- a/test/tool-surface.test.js
+++ b/test/tool-surface.test.js
@@ -1,0 +1,90 @@
+/**
+ * Tool surface reduction — hardens the native OpenClaw tool surface so the
+ * agent sees only what Limbo's use case needs (MCP vault/workspace/cron/
+ * calendar plus session_status). Reduces model confusion from overlapping
+ * tools and closes the gateway/cron/fs self-mutation backdoors.
+ *
+ * Design:
+ *   - tools.profile = "minimal"      → base allowlist = { session_status }
+ *   - tools.allow   = [session_status]  (explicit, redundant-by-design)
+ *   - tools.deny    = [gateway, cron]  → belt-and-suspenders for the two
+ *                                        native tools that are most dangerous
+ *                                        (self-reconfig) or most redundant
+ *                                        (cron duplicates our MCP cron_*).
+ *   - regen script appends web_search + web_fetch to tools.allow when
+ *     WEB_SEARCH_ENABLED=true — so the web toggle still works end-to-end
+ *     now that the base profile is minimal.
+ *
+ * MCP tools (vault_*, workspace_*, cron_*, calendar_*, update_instance) are
+ * exposed via mcp.servers.limbo-vault and are NOT affected by tools.profile
+ * — they always appear to the agent regardless of native tool config.
+ */
+
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ROOT = path.resolve(__dirname, '..');
+function read(rel) { return fs.readFileSync(path.join(ROOT, rel), 'utf8'); }
+
+function renderTemplate() {
+  let json = read('openclaw.json.template');
+  json = json.replace(/\$\{LIMBO_PORT\}/g, '18789');
+  json = json.replace(/\$\{MODEL_PROVIDER\}/g, 'anthropic');
+  json = json.replace(/\$\{MODEL_NAME\}/g, 'claude-sonnet-4-6');
+  json = json.replace(/\$\{RUNTIME_REASONING_EFFORT\}/g, 'medium');
+  json = json.replace(/\$\{OPENCLAW_STATE_DIR\}/g, '/home/limbo/.openclaw');
+  return JSON.parse(json);
+}
+
+test('template uses profile "minimal" (not "full")', () => {
+  const cfg = renderTemplate();
+  assert.equal(cfg.tools.profile, 'minimal',
+    'profile:full exposes ~40 native tools and confuses the model. Use minimal.');
+});
+
+test('template explicitly allows session_status', () => {
+  const cfg = renderTemplate();
+  assert.ok(Array.isArray(cfg.tools.allow), 'tools.allow must be an array');
+  assert.ok(cfg.tools.allow.includes('session_status'),
+    'session_status is the only native tool Limbo needs — keep it explicit');
+});
+
+test('template denies gateway (self-reconfig backdoor)', () => {
+  const cfg = renderTemplate();
+  assert.ok(Array.isArray(cfg.tools.deny), 'tools.deny must be an array');
+  assert.ok(cfg.tools.deny.includes('gateway'),
+    'The native gateway tool lets the agent patch its own config and restart');
+});
+
+test('template denies native cron (duplicate of MCP cron_*)', () => {
+  const cfg = renderTemplate();
+  assert.ok(cfg.tools.deny.includes('cron'),
+    'Our MCP cron_add/list/remove already wraps cron; the native tool is a confusing duplicate');
+});
+
+test('template does NOT include message in allow (replies are channel-routed automatically)', () => {
+  const cfg = renderTemplate();
+  const allow = cfg.tools.allow || [];
+  assert.ok(!allow.includes('message'),
+    'OpenClaw routes replies back to the inbound channel without the message tool');
+});
+
+test('template does NOT include media tools in allow (vision is in the model, not a tool)', () => {
+  const cfg = renderTemplate();
+  const allow = cfg.tools.allow || [];
+  for (const t of ['image', 'image_generate', 'video_generate', 'music_generate', 'tts']) {
+    assert.ok(!allow.includes(t), `${t} should stay behind profile:minimal`);
+  }
+});
+
+test('regen script adds web_search + web_fetch to tools.allow when WEB_SEARCH_ENABLED=true', () => {
+  const regen = read('scripts/regen-openclaw-config.sh');
+  assert.ok(regen.includes('web_search'),
+    'Regen script must push web_search into tools.allow when web search is enabled — otherwise profile:minimal strips it');
+  assert.ok(regen.includes('web_fetch'),
+    'web_fetch complements web_search for fetching page content');
+});

--- a/workspace/system/TOOLS.md
+++ b/workspace/system/TOOLS.md
@@ -1,5 +1,27 @@
 # Tools & Processing Rules
 
+## Your complete tool inventory
+
+These are ALL the tools you have. If something you want to do isn't in this list, you can't do it — tell the user honestly instead of inventing a tool name.
+
+**Memory (vault):** `vault_search`, `vault_read`, `vault_write_note`, `vault_update_map`, `vault_store_file`, `vault_get_file`
+
+**Your persona files:** `workspace_read`, `workspace_write`
+
+**Reminders:** `cron_add`, `cron_list`, `cron_remove`
+
+**Calendar** (only if Google Calendar is connected): `calendar_read`, `calendar_create`, `calendar_update`, `calendar_delete`
+
+**Self-update:** `update_instance`
+
+**Session introspection:** `session_status`
+
+That's it. You do **not** have: shell/exec, file editing, browser, code execution, image/video/audio generation, a `message` tool. Replies to the user are delivered automatically by the channel — just write your reply as normal text.
+
+Inbound images and audio are understood by the model directly — no tool call needed. If the user sends a photo, describe what you see in your reply.
+
+---
+
 All your tools are MCP tools. Call them by name.
 
 **⚠️ ALL user information goes to the vault via vault tools. Always.**


### PR DESCRIPTION
## Summary

Switch OpenClaw from `profile: "full"` (exposing ~40 native tools) to `profile: "minimal"` with an explicit allow of `session_status` and a defensive deny of `gateway` + `cron`.

Native tools reduced from ~40 → 1 (`session_status`). MCP tools unchanged (16 tools, always available via `mcp.servers.limbo-vault`). Agent now sees a clear, narrow surface matching Limbo's actual use case.

## Why

- **Anthropic's guidance** (Writing tools for agents) + benchmarks ([MCPVerse arXiv:2508.16260](https://arxiv.org/html/2508.16260v2), [RAG-MCP arXiv:2505.03275](https://arxiv.org/pdf/2505.03275)) show that overlapping / surplus tools degrade tool selection and bloat context.
- MCP already covers every domain capability Limbo needs (`vault_*`, `workspace_*`, `cron_*`, `calendar_*`, `update_instance`). Native `exec`, `browser`, `memory_search`, `message`, etc. on top only created ambiguity.
- `gateway` tool lets the agent patch its own config and self-restart — zero legitimate use, kept in `deny`.
- Native `cron` duplicates our MCP `cron_add/list/remove` — confusing for the model.

## Web search stays functional

`WEB_SEARCH_ENABLED=true` + `BRAVE_API_KEY` still enables web search end-to-end. The regen script now pushes `web_search` + `web_fetch` into `tools.allow` alongside the existing `tools.web.search` provider block — both halves are required under `profile: minimal`.

## Changes

- `openclaw.json.template` → `profile: "minimal"`, `allow: ["session_status"]`, `deny: ["gateway", "cron"]`
- `scripts/regen-openclaw-config.sh` → conditional push of `web_search`/`web_fetch` into allow when web search is on
- `workspace/system/TOOLS.md` → explicit tool inventory at top so the agent knows what it can and can't do
- `test/tool-surface.test.js` → new suite validating template shape + regen behavior
- Updated two pre-existing tests that hardcoded `profile: "full"`

## Test plan

- [x] Unit suite 523/523 green (`npm test`)
- [x] Fresh container boot → `openclaw.json` has the expected tools block; gateway starts clean
- [ ] Live smoke test: `openclaw agent --message "search my vault for X"` confirms vault_* still reachable (blocked on separate disk-space issue in test tmpfs; will verify in follow-up)
- [ ] Cost/latency comparison: measure turn-over-turn token usage vs. current prod to confirm the reduction shows up in bills

🤖 Generated with [Claude Code](https://claude.com/claude-code)