### PR TITLE
feat(media): audio + image understanding via LiteLLM (no direct provider keys)

### DIFF
--- a/docker-compose.local-whatsapp.yml
+++ b/docker-compose.local-whatsapp.yml
@@ -97,6 +97,12 @@ services:
       - /tmp/limbo-local-whatsapp/openclaw-state:/home/limbo/.openclaw
       - /tmp/limbo-local-whatsapp/config:/data/config
       - /tmp/limbo-local-whatsapp/flags:/flags
+      # Dev-only: live-mount the local kapso plugin over the image's global
+      # install so iteration is `npm run build` + `docker compose restart limbo`.
+      # Comment out after shipping.
+      - /Users/tomasward/Desktop/Dev/openclaw-whatsapp-kapso/dist:/usr/local/lib/node_modules/openclaw-whatsapp-kapso/dist:ro
+      - /Users/tomasward/Desktop/Dev/openclaw-whatsapp-kapso/package.json:/usr/local/lib/node_modules/openclaw-whatsapp-kapso/package.json:ro
+      - /Users/tomasward/Desktop/Dev/openclaw-whatsapp-kapso/openclaw.plugin.json:/usr/local/lib/node_modules/openclaw-whatsapp-kapso/openclaw.plugin.json:ro
     env_file:
       - /tmp/limbo-local-whatsapp/config/.env
     environment:

--- a/docker-compose.local-whatsapp.yml
+++ b/docker-compose.local-whatsapp.yml
@@ -97,12 +97,14 @@ services:
       - /tmp/limbo-local-whatsapp/openclaw-state:/home/limbo/.openclaw
       - /tmp/limbo-local-whatsapp/config:/data/config
       - /tmp/limbo-local-whatsapp/flags:/flags
-      # Dev-only: live-mount the local kapso plugin over the image's global
-      # install so iteration is `npm run build` + `docker compose restart limbo`.
-      # Comment out after shipping.
-      - /Users/tomasward/Desktop/Dev/openclaw-whatsapp-kapso/dist:/usr/local/lib/node_modules/openclaw-whatsapp-kapso/dist:ro
-      - /Users/tomasward/Desktop/Dev/openclaw-whatsapp-kapso/package.json:/usr/local/lib/node_modules/openclaw-whatsapp-kapso/package.json:ro
-      - /Users/tomasward/Desktop/Dev/openclaw-whatsapp-kapso/openclaw.plugin.json:/usr/local/lib/node_modules/openclaw-whatsapp-kapso/openclaw.plugin.json:ro
+      # To iterate on the kapso plugin without re-publishing to npm, add to a
+      # `docker-compose.local-whatsapp.override.yml`:
+      #   services:
+      #     limbo:
+      #       volumes:
+      #         - <path-to>/openclaw-whatsapp-kapso/dist:/usr/local/lib/node_modules/openclaw-whatsapp-kapso/dist:ro
+      # and bring up with `-f docker-compose.local-whatsapp.yml -f
+      # docker-compose.local-whatsapp.override.yml`.
     env_file:
       - /tmp/limbo-local-whatsapp/config/.env
     environment:

--- a/litellm-config.yaml.template
+++ b/litellm-config.yaml.template
@@ -40,6 +40,27 @@ model_list:
         - location: message
           role: system
 
+  # Audio transcription via Groq Whisper.
+  #
+  # Exposed as an openai-compatible transcription endpoint on LiteLLM so
+  # OpenClaw's `groq` media-understanding provider (which POSTs OpenAI-
+  # format to {baseUrl}/audio/transcriptions) can be pointed at LiteLLM
+  # using baseUrl=http://litellm:4000/v1 and the user's virtual key instead
+  # of a direct Groq key. The master GROQ_API_KEY stays in the LiteLLM
+  # container env only; virtual-key budgets (limbo-plan quotas) cover both
+  # chat and transcription usage uniformly.
+  #
+  # Model alias matches the id OpenClaw sends so LiteLLM routes without
+  # rewrites. The bare and qualified rows mirror the Sonnet pattern.
+  - model_name: whisper-large-v3-turbo
+    litellm_params:
+      model: groq/whisper-large-v3-turbo
+      api_key: os.environ/GROQ_API_KEY
+  - model_name: groq/whisper-large-v3-turbo
+    litellm_params:
+      model: groq/whisper-large-v3-turbo
+      api_key: os.environ/GROQ_API_KEY
+
 litellm_settings:
   # Full verbose logging so we can see the outbound request body to Anthropic
   # — needed to verify whether `tools` and `tool_choice` are actually being

--- a/scripts/bootstrap-local-whatsapp.sh
+++ b/scripts/bootstrap-local-whatsapp.sh
@@ -46,6 +46,10 @@ set -a
 set +a
 
 : "${ANTHROPIC_API_KEY:?set ANTHROPIC_API_KEY in .env.local}"
+# GROQ_API_KEY is optional — only required to enable audio transcription.
+# When unset we skip LiteLLM's transcription route; users can still send
+# audio but the agent sees the envelope's MediaPath without a transcript.
+GROQ_API_KEY="${GROQ_API_KEY:-}"
 : "${KAPSO_API_KEY:?set KAPSO_API_KEY in .env.local}"
 : "${KAPSO_PHONE_NUMBER_ID:?set KAPSO_PHONE_NUMBER_ID in .env.local}"
 
@@ -113,8 +117,11 @@ EOF
 chmod 600 "$CONFIG_DIR/postgres.env"
 
 # LiteLLM env (read by the litellm service).
+# GROQ_API_KEY lives ONLY in this container — virtual keys minted by LiteLLM
+# wrap it so tenants get transcription without seeing the raw key.
 cat > "$CONFIG_DIR/litellm.env" <<EOF
 ANTHROPIC_API_KEY=$ANTHROPIC_API_KEY
+GROQ_API_KEY=$GROQ_API_KEY
 LITELLM_MASTER_KEY=$LITELLM_MASTER_KEY
 DATABASE_URL=postgresql://litellm:$POSTGRES_PASSWORD@postgres:5432/litellm
 STORE_MODEL_IN_DB=True
@@ -189,6 +196,13 @@ MODEL_NAME=claude-sonnet-4-6
 LLM_API_KEY=$VIRTUAL_KEY
 LITELLM_ENABLED=true
 LITELLM_URL=http://litellm:4000
+# OpenClaw's media-understanding pre-check validates that the `groq`
+# provider has *some* key before routing transcription. The actual call
+# uses our `request.auth.token` override (the virtual key) which LiteLLM
+# then swaps for its real GROQ_API_KEY upstream. Any value here passes
+# the pre-check — using LLM_API_KEY keeps it token-shaped.
+GROQ_API_KEY=$VIRTUAL_KEY
+VOICE_ENABLED=true
 
 # ── WhatsApp (Kapso) channel ───────────────────────────────────────
 CHANNEL_ADAPTER_WHATSAPP_KAPSO_ENABLED=true
@@ -198,7 +212,6 @@ KAPSO_WEBHOOK_SECRET=${KAPSO_WEBHOOK_SECRET:-}
 
 # ── Legacy features (deprecated; disabled in local MVP) ────────────
 TELEGRAM_ENABLED=false
-VOICE_ENABLED=false
 WEB_SEARCH_ENABLED=false
 GOOGLE_CALENDAR_ENABLED=false
 EOF

--- a/scripts/regen-openclaw-config.sh
+++ b/scripts/regen-openclaw-config.sh
@@ -235,18 +235,93 @@ if [ "$CHANNEL_ADAPTER_WHATSAPP_KAPSO_ENABLED" = "true" ] && \
   " "$TMP_CONFIG"
 fi
 
-# Voice transcription (Groq) — pin audio provider to bypass the auto-resolver
-if [ "$VOICE_ENABLED" = "true" ] && [ -n "$GROQ_API_KEY" ]; then
-  export GROQ_API_KEY
+# Voice transcription — routed through LiteLLM instead of hitting Groq directly.
+#
+# LiteLLM exposes /v1/audio/transcriptions (openai-compatible) and routes the
+# `whisper-large-v3-turbo` alias to its Groq backend using the shared
+# GROQ_API_KEY that lives in the LiteLLM container's env. The tenant's
+# LLM_API_KEY virtual key budget covers both chat + transcription usage, so
+# Limbo never needs a Groq key of its own.
+#
+# We use provider='groq' because OpenClaw's groq media-understanding provider
+# knows how to build the POST body for Whisper; the baseUrl + auth.token
+# overrides redirect the actual HTTP call to LiteLLM.
+if [ "$LITELLM_ENABLED" = "true" ] && [ -n "$LITELLM_URL" ] && [ -n "$LLM_API_KEY" ]; then
+  # OpenClaw's media-understanding layer does a pre-check that the `groq`
+  # provider has *some* API key registered before building the HTTP request.
+  # It reads this from the process env. Our request.auth.token override
+  # replaces the Authorization header on the actual call (so the real key
+  # used upstream is LiteLLM's GROQ_API_KEY in the LiteLLM container), but
+  # we still need to satisfy the pre-check. Stuffing the tenant's virtual
+  # key here works for both: LiteLLM accepts it on its own endpoint, and
+  # OpenClaw sees "provider has a key" and proceeds.
+  export GROQ_API_KEY="${GROQ_API_KEY:-$LLM_API_KEY}"
+  export LITELLM_URL LLM_API_KEY
   node -e "
     const fs = require('fs');
     const cfg = JSON.parse(fs.readFileSync(process.argv[1], 'utf8'));
     cfg.tools = cfg.tools || {};
     cfg.tools.media = cfg.tools.media || {};
     cfg.tools.media.audio = cfg.tools.media.audio || {};
-    cfg.tools.media.audio.models = [
-      { provider: 'groq', model: 'whisper-large-v3-turbo' }
-    ];
+    // allowPrivateNetwork only lives under models.providers.*.request in the
+    // openclaw schema (audit-wise, SSRF policy is a provider-wide opt-in —
+    // it can't be scoped to a single tools.media.*.models[] row). So we
+    // register the groq and litellm providers with their baseUrl, apiKey,
+    // and allowPrivateNetwork, and the tools.media.{audio,image}.models[]
+    // entries just reference them by id.
+    cfg.models = cfg.models || {};
+    cfg.models.providers = cfg.models.providers || {};
+
+    // Groq: the media-understanding transcription runner looks up the
+    // provider HTTP policy here for SSRF + headers. We only need the
+    // allowPrivateNetwork opt-in at this layer — the actual baseUrl +
+    // auth override for the transcription call lives on the
+    // tools.media.audio.models[] entry below (where the runner
+    // constructs the request). Models array is required by the schema
+    // but empty is fine because the model id for audio is set on the
+    // tools.media.audio.models[].model field, not on this registry.
+    cfg.models.providers.groq = {
+      baseUrl: process.env.LITELLM_URL + '/v1',
+      apiKey: process.env.LLM_API_KEY,
+      request: { allowPrivateNetwork: true },
+      models: [],
+    };
+
+    // Custom litellm provider for the image tool — pi-ai's openai transport
+    // will consume an OpenAI-shape /v1/chat/completions multimodal call,
+    // which LiteLLM translates to Anthropic's image content blocks upstream.
+    // Declaring input: ['text','image'] is what makes resolveImageRuntime's
+    // registry lookup accept this provider/model for the image capability.
+    cfg.models.providers.litellm = {
+      baseUrl: process.env.LITELLM_URL + '/v1',
+      apiKey: process.env.LLM_API_KEY,
+      api: 'openai-completions',
+      request: { allowPrivateNetwork: true },
+      models: [
+        {
+          id: 'claude-sonnet-4-6',
+          name: 'Claude Sonnet via LiteLLM',
+          input: ['text', 'image'],
+          maxTokens: 8192,
+        },
+      ],
+    };
+
+    cfg.tools.media.audio.models = [{
+      provider: 'groq',
+      model: 'whisper-large-v3-turbo',
+      baseUrl: process.env.LITELLM_URL + '/v1',
+      request: {
+        auth: { mode: 'authorization-bearer', token: process.env.LLM_API_KEY },
+      },
+    }];
+
+    cfg.tools.media.image = cfg.tools.media.image || {};
+    cfg.tools.media.image.models = [{
+      provider: 'litellm',
+      model: 'claude-sonnet-4-6',
+    }];
+
     fs.writeFileSync(process.argv[1], JSON.stringify(cfg, null, 2));
   " "$TMP_CONFIG"
 fi


### PR DESCRIPTION
## Summary
Audio transcription (Groq Whisper) and image understanding (Claude Sonnet 4.6 vision) are now both routed through the LiteLLM sidecar using the tenant's virtual key. The underlying provider keys (GROQ_API_KEY, ANTHROPIC_API_KEY) live only in the LiteLLM container — limbo never sees them, which is what the multi-tenant plan requires.

Sits on top of #269 (native Kapso plugin) and closes the loop for inbound WhatsApp media.

## Changes
- **LiteLLM** (`litellm-config.yaml.template`): adds `whisper-large-v3-turbo` → `groq/whisper-large-v3-turbo` with the master `GROQ_API_KEY`
- **OpenClaw config** (`scripts/regen-openclaw-config.sh`):
  - `models.providers.groq` with `request.allowPrivateNetwork: true` + empty models array (satisfies schema; real whisper id is on the tools.media entry)
  - `models.providers.litellm` — custom provider with `api: openai-completions` + a `claude-sonnet-4-6` model tagged `input: ["text","image"]` so `resolveImageRuntime`'s registry lookup accepts it
  - `tools.media.audio.models[0]` points at LiteLLM with the virtual key as bearer
  - `tools.media.image.models[0]` uses provider `litellm`, model `claude-sonnet-4-6`
- **Bootstrap** (`scripts/bootstrap-local-whatsapp.sh`): writes `GROQ_API_KEY=$VIRTUAL_KEY` into the limbo container env (pre-check passthrough; actual upstream key stays in LiteLLM); `VOICE_ENABLED=true` by default
- **Compose** (`docker-compose.local-whatsapp.yml`): dev-only volume mount for the local kapso plugin dist — remove before shipping

## Test plan
- [x] Send audio via WhatsApp → transcribed, agent replies from transcript
- [x] Send image via WhatsApp → agent describes content
- [x] Session reset cleans stale "model can't see images" hallucination
- [x] `npm test` passes (526/526)

## Known gap
- Image path uses `api: openai-completions` which goes to LiteLLM's chat endpoint. If LiteLLM's OpenAI→Anthropic multimodal translation has edge cases (historical [BerriAI/litellm#6893](https://github.com/BerriAI/litellm/issues/6893) style), we'd fall through. On current versions of both, works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)