### PR TITLE
chore(kapso): bump whatsapp-kapso plugin to ^2026.4.30 (typing + media)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends gettext-base tz
 # crashes with "Cannot find module 'grammy'" even when TELEGRAM_ENABLED=false.
 # Pinned to the version that ships with OpenClaw's lockfile to avoid accidental
 # API drift. Bump when OpenClaw's own grammy peer range shifts.
-RUN npm install -g "openclaw@${OPENCLAW_VERSION}" "@googleworkspace/cli@0.22.3" "grammy@^1.31.0" "openclaw-whatsapp-kapso@^2026.4.28"
+RUN npm install -g "openclaw@${OPENCLAW_VERSION}" "@googleworkspace/cli@0.22.3" "grammy@^1.31.0" "openclaw-whatsapp-kapso@^2026.4.29"
 
 # Apply local patch for openclaw#63851 — the guarded fetch drops FormData fields,
 # breaking Groq audio transcription. Remove this once upstream PR #64349 ships in

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends gettext-base tz
 # crashes with "Cannot find module 'grammy'" even when TELEGRAM_ENABLED=false.
 # Pinned to the version that ships with OpenClaw's lockfile to avoid accidental
 # API drift. Bump when OpenClaw's own grammy peer range shifts.
-RUN npm install -g "openclaw@${OPENCLAW_VERSION}" "@googleworkspace/cli@0.22.3" "grammy@^1.31.0" "openclaw-whatsapp-kapso@^2026.4.29"
+RUN npm install -g "openclaw@${OPENCLAW_VERSION}" "@googleworkspace/cli@0.22.3" "grammy@^1.31.0" "openclaw-whatsapp-kapso@^2026.4.30"
 
 # Apply local patch for openclaw#63851 — the guarded fetch drops FormData fields,
 # breaking Groq audio transcription. Remove this once upstream PR #64349 ships in


### PR DESCRIPTION
## Summary
- Bumps `openclaw-whatsapp-kapso` pin in the Dockerfile from `^2026.4.28` → `^2026.4.29`
- The new plugin version adds **mark-as-read + typing indicator** on every inbound WhatsApp message
- User sees two blue checks and \"typing...\" in their WhatsApp client the moment the agent starts processing; auto-clears when the reply goes out or after 25s (Meta cap)

## Context
- Published: https://www.npmjs.com/package/openclaw-whatsapp-kapso/v/2026.4.29
- Plugin PR (merged): https://github.com/TomasWard1/openclaw-whatsapp-kapso/pull/30
- Errors in the typing-indicator call are logged at `warn` and swallowed — never blocks the inbound dispatch

## Prod env follow-up
Para el switch al número real de Kapso hay que actualizar el secret `KAPSO_PHONE_NUMBER_ID` en staging (ese valor ya no vive en el repo).

## Test plan
- [ ] CI green
- [ ] Merge + redeploy staging
- [ ] Mandar msj de WhatsApp → ver doble tilde azul + \"typing...\" antes de que llegue la respuesta

🤖 Generated with [Claude Code](https://claude.com/claude-code)